### PR TITLE
Support for [patch] & [replace] directives in member & workspace manifests

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -11,13 +11,7 @@ use std::path::PathBuf;
 use toml::Value;
 
 pub fn get_manifest(manifest_dir: &Path) -> Manifest {
-    match try_get_manifest(manifest_dir) {
-        Ok(manifest) => manifest,
-        Err(err) => {
-            eprintln!("Error: {:?}", err);
-            Manifest::default()
-        }
-    }
+    try_get_manifest(manifest_dir).unwrap_or_default()
 }
 
 fn try_get_manifest(manifest_dir: &Path) -> Result<Manifest, Error> {
@@ -68,6 +62,7 @@ pub struct WorkspaceManifest {
     #[serde(default)]
     pub members: Members,
     pub patch: Option<Map<String, RegistryPatch>>,
+    pub replace: Option<Map<String, Replacement>>,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -127,6 +122,8 @@ pub struct Patch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
 }
+
+pub type Replacement = Patch;
 
 fn get_true() -> bool {
     true

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -72,11 +72,21 @@ fn fix_replacements(replacements: &mut Map<String, Replacement>, dir: &Path) {
     }
 }
 
-#[derive(Deserialize, Default, Debug)]pub struct WorkspaceManifest {
+#[derive(Deserialize, Default, Debug)]
+pub struct WorkspaceManifest {
     #[serde(default)]
     pub members: Members,
     pub patch: Option<Map<String, RegistryPatch>>,
     pub replace: Option<Map<String, Replacement>>,
+}
+
+impl WorkspaceManifest {
+    /// Within a workspace the [patch], [replace] and [profile.*] sections in Cargo.toml are only
+    /// recognized in the root crate's manifest, and ignored in member crates' manifests:
+    pub fn apply_to(&self, manifest: &mut Manifest) {
+        manifest.patch = self.patch.clone();
+        manifest.replace = self.replace.clone();
+    }
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::dependencies::{Dependency, RegistryPatch};
+use crate::dependencies::{Dependency, RegistryPatch, Replacement};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap as Map;
 use std::ffi::OsStr;
@@ -16,6 +16,8 @@ pub struct Manifest {
     pub workspace: Option<Workspace>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub patch: Option<Map<String, RegistryPatch>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replace: Option<Map<String, Replacement>>,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,4 @@
-use crate::dependencies::Dependency;
+use crate::dependencies::{Dependency, RegistryPatch};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap as Map;
 use std::ffi::OsStr;
@@ -14,6 +14,8 @@ pub struct Manifest {
     pub bins: Vec<Bin>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace: Option<Workspace>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch: Option<Map<String, RegistryPatch>>,
 }
 
 #[derive(Serialize, Debug)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -124,8 +124,9 @@ impl Runner {
             let manifest_dir = project.source_dir.join(workspace);
             if let Ok(workspace_manifest) = dependencies::try_get_workspace_manifest(&manifest_dir)
             {
-                let dependencies::WorkspaceManifest { patch, .. } = workspace_manifest;
+                let dependencies::WorkspaceManifest { patch, replace, .. } = workspace_manifest;
                 source_manifest.patch = patch;
+                source_manifest.replace = replace;
             }
         }
 
@@ -150,6 +151,7 @@ impl Runner {
             bins: Vec::new(),
             workspace: Some(Workspace {}),
             patch: source_manifest.patch,
+            replace: source_manifest.replace,
         };
 
         manifest.dependencies.extend(source_manifest.dependencies);

--- a/src/run.rs
+++ b/src/run.rs
@@ -120,6 +120,15 @@ impl Runner {
     ) -> Result<Manifest> {
         let mut source_manifest = dependencies::get_manifest(&project.source_dir);
 
+        if let Some(workspace) = &source_manifest.package.workspace {
+            let manifest_dir = project.source_dir.join(workspace);
+            if let Ok(workspace_manifest) = dependencies::try_get_workspace_manifest(&manifest_dir)
+            {
+                let dependencies::WorkspaceManifest { patch, .. } = workspace_manifest;
+                source_manifest.patch = patch;
+            }
+        }
+
         let features = source_manifest
             .features
             .keys()

--- a/src/run.rs
+++ b/src/run.rs
@@ -118,7 +118,7 @@ impl Runner {
         project: &Project,
         tests: &[ExpandedTest],
     ) -> Result<Manifest> {
-        let source_manifest = dependencies::get(&project.source_dir);
+        let mut source_manifest = dependencies::get_manifest(&project.source_dir);
 
         let features = source_manifest
             .features
@@ -140,6 +140,7 @@ impl Runner {
             dependencies: Map::new(),
             bins: Vec::new(),
             workspace: Some(Workspace {}),
+            patch: source_manifest.patch,
         };
 
         manifest.dependencies.extend(source_manifest.dependencies);


### PR DESCRIPTION
This PR adds support for `[patch]` and `[replace]` directives in both member and workspace manifests, according to [The Manifest Format](https://doc.rust-lang.org/cargo/reference/manifest.html#the-workspace-section) (emphasis mine):

> Workspaces were added to Cargo as part of RFC 1525 and have a number of properties:
> 
> - A workspace can contain multiple crates where one of them is the root crate.
> - The root crate's Cargo.toml contains the [workspace] table, but is not required to have other configuration.
> - Whenever any crate in the workspace is compiled, output is placed in the workspace root (i.e., next to the root crate's Cargo.toml).
> - The lock file for all crates in the workspace resides in the workspace root.
> - **The [patch], [replace] and [profile.*] sections in Cargo.toml are only recognized in the root crate's manifest, and ignored in member crates' manifests.**

<strike>With one caveat: I only implemented support for workspace directives for the case where the member manifest explicitly provides the workspace path, such as:

```toml
[package]
workspace = ".."
```
 
This spared me from extracting/re-implementing the root-finding logic of [rust-lang/cargo/…/core/workspace.rs](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/workspace.rs).

It seemed like a reasonable compromise to me as having to maintain the latter feels like a bit of an overkill, given the far simpler workaround. Having to add a simple `[package.workspace]` should break anybody's project, should it?
</strike>

Edit: Making use of `$ cargo metadata` now for full workspace-support.

Fixes https://github.com/dtolnay/trybuild/issues/3.