### PR TITLE
Added `#[derive(Debug)]` for easier inspection of manifest structs, etc

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -33,7 +33,7 @@ fn make_relative(dependencies: &mut Map<String, Dependency>, dir: &Path) {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Debug)]
 pub struct Manifest {
     #[serde(default)]
     pub package: Package,
@@ -45,13 +45,13 @@ pub struct Manifest {
     pub dev_dependencies: Map<String, Dependency>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Debug)]
 pub struct Package {
     #[serde(default)]
     pub edition: Edition,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(remote = "Self")]
 pub struct Dependency {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use std::env;
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub enum Update {
     Wip,
     Overwrite,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Display};
 use std::io;
 use std::path::PathBuf;
 
+#[derive(Debug)]
 pub enum Error {
     Cargo(io::Error),
     CargoFail,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,21 +223,23 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::thread;
 
+#[derive(Debug)]
 pub struct TestCases {
     runner: RefCell<Runner>,
 }
 
+#[derive(Debug)]
 struct Runner {
     tests: Vec<Test>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Test {
     path: PathBuf,
     expected: Expected,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum Expected {
     Pass,
     CompileFail,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap as Map;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Manifest {
     pub package: Package,
     #[serde(skip_serializing_if = "Map::is_empty")]
@@ -16,7 +16,7 @@ pub struct Manifest {
     pub workspace: Option<Workspace>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Package {
     pub name: String,
     pub version: String,
@@ -24,7 +24,7 @@ pub struct Package {
     pub publish: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum Edition {
     #[serde(rename = "2015")]
     E2015,
@@ -32,26 +32,26 @@ pub enum Edition {
     E2018,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Bin {
     pub name: Name,
     pub path: PathBuf,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct Name(pub String);
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Config {
     pub build: Build,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Build {
     pub rustflags: Vec<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Workspace {}
 
 impl Default for Edition {

--- a/src/run.rs
+++ b/src/run.rs
@@ -16,6 +16,7 @@ use crate::message;
 use crate::normalize;
 use crate::rustflags;
 
+#[derive(Debug)]
 pub struct Project {
     pub dir: PathBuf,
     source_dir: PathBuf,
@@ -292,6 +293,7 @@ fn check_exists(path: &Path) -> Result<()> {
     }
 }
 
+#[derive(Debug)]
 struct ExpandedTest {
     name: Name,
     test: Test,


### PR DESCRIPTION
While working on https://github.com/dtolnay/trybuild/pull/17 I occasionally needed to peek into the contents of the manifest structs being modified by trybuild. The current lack of `#[derive(debug)]` made this rather cumbersome at times.