### PR TITLE
Ignore test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ enum Expected {
 impl TestCases {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let include = std::env::args().into_iter().collect();
+        let include = std::env::args().collect();
 
         TestCases {
             runner: RefCell::new(Runner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,7 @@ pub struct TestCases {
 #[derive(Debug)]
 struct Runner {
     tests: Vec<Test>,
+    include: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -246,8 +247,13 @@ enum Expected {
 impl TestCases {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
+        let include = std::env::args().into_iter().collect();
+
         TestCases {
-            runner: RefCell::new(Runner { tests: Vec::new() }),
+            runner: RefCell::new(Runner {
+                tests: Vec::new(),
+                include,
+            }),
         }
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -63,8 +63,8 @@ impl Runner {
     }
 
     // returns vec of removed items so it mimics std's drain_filter some what, and
-    // incase, instead of running nothing you want to run all tests if none are found
-    // matching self.included (trybuild=foo.rs)
+    // incase instead of running nothing you want to run all tests if none are found
+    // matching self.included (trybuild=foo.rs) self.drain_filter returns full ExpandedTest Vec
     fn drain_filter(&self, tests: &mut Vec<ExpandedTest>) -> Vec<ExpandedTest> {
         fn _drain_filter(name: Option<&str>, tests: &mut Vec<ExpandedTest>) -> Vec<ExpandedTest> {
             let mut v = Vec::new();
@@ -95,7 +95,7 @@ impl Runner {
                 if f.contains("trybuild=") {
                     let arg: Vec<_> = f.split('=').collect();
                     // is there a more direct way to do this or just have
-                    // _drain_filter take a Option<&&str> instead
+                    // _drain_filter take a Option<&&str> instead 
                     let a = arg.last().map(|s| *s);
                     _drain_filter(a, tests)
                 } else {


### PR DESCRIPTION
After expand_globs Runner's new drain_filter method removes tests if a 3rd argument with trybuild= is included.  If no matches are found no tests run and the appropriate message is printed. I added an include field to the Runner struct which is the env::args(). Any suggestions I'm happy to change.