### PR TITLE
Highlight "EXPECTED" and "ACTUAL" snippets in diff-like style on mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0"
 toml = "0.5"
+difference = "2.0"

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,4 @@
+use difference::{Changeset, Difference};
 use termcolor::Color::{self, *};
 
 use super::{Expected, Test};
@@ -5,8 +6,64 @@ use crate::error::Error;
 use crate::normalize;
 use crate::term;
 
+use std::cmp::min;
 use std::path::Path;
 use std::process::Output;
+
+const EXPECTED_COLOR: Color = Blue;
+const ACTUAL_COLOR: Color = Red;
+const WIP_COLOR: Color = Yellow;
+const WARN_COLOR: Color = Yellow;
+const ERR_COLOR: Color = Red;
+const OK_COLOR: Color = Green;
+
+macro_rules! impl_print {
+    ($macro_:ident, $func:ident, $color:expr, $fmt:expr, $($args:expr),*) => {{
+        term::$func($color);
+        $macro_!($fmt, $($args),*);
+        term::reset();
+    }};
+}
+
+macro_rules! println_color {
+    ($color:expr, $fmt:expr, $($args:expr),*) => {{
+        impl_print!(println, color, $color, $fmt, $($args),*)
+    }};
+
+    ($color:expr, $fmt:expr) => { println_color!($color, $fmt,) };
+}
+
+macro_rules! println_bold {
+    ($color:expr, $fmt:expr, $($args:expr),*) => {{
+        impl_print!(println, bold_color, $color, $fmt, $($args),*)
+    }};
+
+    ($color:expr, $fmt:expr) => { println_bold!($color, $fmt,) };
+}
+
+macro_rules! print_color {
+    ($color:expr, $fmt:expr, $($args:expr),*) => {{
+        impl_print!(print, color, $color, $fmt, $($args),*)
+    }};
+
+    ($color:expr, $fmt:expr) => { print_color!($color, $fmt,) };
+}
+
+macro_rules! print_bold {
+    ($color:expr, $fmt:expr, $($args:expr),*) => {{
+        impl_print!(print, bold_color, $color, $fmt, $($args),*)
+    }};
+
+    ($color:expr, $fmt:expr) => { print_bold!($color, $fmt,) };
+}
+
+macro_rules! print_bg_color {
+    ($color:expr, $fmt:expr, $($args:expr),*) => {{
+        impl_print!(print, bg_color, $color, $fmt, $($args),*)
+    }};
+
+    ($color:expr, $fmt:expr) => { print_bg_color!($color, $fmt,) };
+}
 
 pub(crate) enum Level {
     Fail,
@@ -20,9 +77,7 @@ pub(crate) fn prepare_fail(err: Error) {
         return;
     }
 
-    term::bold_color(Red);
-    print!("ERROR");
-    term::reset();
+    print_bold!(ERR_COLOR, "ERROR");
     println!(": {}", err);
     println!();
 }
@@ -32,24 +87,17 @@ pub(crate) fn test_fail(err: Error) {
         return;
     }
 
-    term::bold_color(Red);
-    println!("error");
-    term::color(Red);
-    println!("{}", err);
-    term::reset();
+    println_bold!(ERR_COLOR, "error");
+    println_color!(ERR_COLOR, "{}", err);
     println!();
 }
 
 pub(crate) fn no_tests_enabled() {
-    term::color(Yellow);
-    println!("There are no tests enabled yet.");
-    term::reset();
+    println_color!(WARN_COLOR, "There are no tests enabled yet.");
 }
 
 pub(crate) fn ok() {
-    term::color(Green);
-    println!("ok");
-    term::reset();
+    println_color!(OK_COLOR, "ok");
 }
 
 pub(crate) fn begin_test(test: &Test, show_expected: bool) {
@@ -78,18 +126,17 @@ pub(crate) fn begin_test(test: &Test, show_expected: bool) {
 }
 
 pub(crate) fn failed_to_build(stderr: &str) {
-    term::bold_color(Red);
-    println!("error");
-    snippet(Red, stderr);
+    println_bold!(ERR_COLOR, "error");
+    snippet(ERR_COLOR, stderr);
     println!();
 }
 
 pub(crate) fn should_not_have_compiled() {
-    term::bold_color(Red);
-    println!("error");
-    term::color(Red);
-    println!("Expected test case to fail to compile, but it succeeded.");
-    term::reset();
+    println_bold!(ERR_COLOR, "error");
+    println_color!(
+        ERR_COLOR,
+        "Expected test case to fail to compile, but it succeeded."
+    );
     println!();
 }
 
@@ -97,46 +144,53 @@ pub(crate) fn write_stderr_wip(wip_path: &Path, stderr_path: &Path, stderr: &str
     let wip_path = wip_path.to_string_lossy();
     let stderr_path = stderr_path.to_string_lossy();
 
-    term::bold_color(Yellow);
-    println!("wip");
+    println_bold!(WIP_COLOR, "wip");
     println!();
-    print!("NOTE");
-    term::reset();
+    print_bold!(WIP_COLOR, "NOTE");
     println!(": writing the following output to `{}`.", wip_path);
     println!(
         "Move this file to `{}` to accept it as correct.",
         stderr_path,
     );
-    snippet(Yellow, stderr);
+    snippet(WIP_COLOR, stderr);
     println!();
 }
 
 pub(crate) fn overwrite_stderr(stderr_path: &Path, stderr: &str) {
     let stderr_path = stderr_path.to_string_lossy();
 
-    term::bold_color(Yellow);
-    println!("wip");
+    println_bold!(WIP_COLOR, "wip");
     println!();
-    print!("NOTE");
-    term::reset();
+    print_bold!(WIP_COLOR, "NOTE");
     println!(": writing the following output to `{}`.", stderr_path);
-    snippet(Yellow, stderr);
+    snippet(WIP_COLOR, stderr);
     println!();
 }
 
 pub(crate) fn mismatch(expected: &str, actual: &str) {
-    term::bold_color(Red);
-    println!("mismatch");
-    term::reset();
+    println_bold!(ERR_COLOR, "mismatch");
     println!();
-    term::bold_color(Blue);
-    println!("EXPECTED:");
-    snippet(Blue, expected);
-    println!();
-    term::bold_color(Red);
-    println!("ACTUAL OUTPUT:");
-    snippet(Red, actual);
-    println!();
+
+    if need_diff(expected, actual) {
+        fn trim_end_lf(s: &str) -> &str {
+            if s.chars().last() == Some('\n') {
+                &s[..s.len() - 1]
+            } else {
+                s
+            }
+        };
+        let expected = trim_end_lf(expected);
+        let actual = trim_end_lf(actual);
+        let diffs = Changeset::new(expected, actual, " ").diffs;
+        print_diff(diffs);
+    } else {
+        println_bold!(EXPECTED_COLOR, "EXPECTED:");
+        snippet(EXPECTED_COLOR, expected);
+        println!();
+        println_bold!(ACTUAL_COLOR, "ACTUAL OUTPUT:");
+        snippet(ACTUAL_COLOR, actual);
+        println!();
+    }
 }
 
 pub(crate) fn output(warnings: &str, output: &Output) {
@@ -151,26 +205,25 @@ pub(crate) fn output(warnings: &str, output: &Output) {
             println!();
         }
     } else {
-        term::bold_color(Red);
-        println!("error");
-        term::color(Red);
+        println_bold!(ERR_COLOR, "error");
         if has_output {
-            println!("Test case failed at runtime.");
+            println_color!(ERR_COLOR, "Test case failed at runtime.");
         } else {
-            println!("Execution of the test case was unsuccessful but there was no output.");
+            println_color!(
+                ERR_COLOR,
+                "Execution of the test case was unsuccessful but there was no output."
+            );
         }
-        term::reset();
         println!();
     }
 
     self::warnings(warnings);
 
-    let color = if success { Yellow } else { Red };
+    let color = if success { WARN_COLOR } else { ERR_COLOR };
 
     for (name, content) in &[("STDOUT", stdout), ("STDERR", stderr)] {
         if !content.is_empty() {
-            term::bold_color(color);
-            println!("{}:", name);
+            println_bold!(color, "{}:", name);
             snippet(color, &normalize::trim(content));
             println!();
         }
@@ -179,13 +232,12 @@ pub(crate) fn output(warnings: &str, output: &Output) {
 
 pub(crate) fn fail_output(level: Level, stdout: &[u8]) {
     let color = match level {
-        Fail => Red,
-        Warn => Yellow,
+        Fail => ERR_COLOR,
+        Warn => WARN_COLOR,
     };
 
     if !stdout.is_empty() {
-        term::bold_color(color);
-        println!("STDOUT:");
+        println_bold!(color, "STDOUT:");
         snippet(color, &normalize::trim(stdout));
         println!();
     }
@@ -196,28 +248,88 @@ pub(crate) fn warnings(warnings: &str) {
         return;
     }
 
-    term::bold_color(Yellow);
-    println!("WARNINGS:");
-    snippet(Yellow, warnings);
+    println_bold!(WARN_COLOR, "WARNINGS:");
+    snippet(WARN_COLOR, warnings);
     println!();
 }
 
 fn snippet(color: Color, content: &str) {
-    fn dotted_line() {
-        println!("{}", "┈".repeat(60));
-    }
-
-    term::color(color);
-    dotted_line();
+    dotted_line(color);
 
     // Color one line at a time because Travis does not preserve color setting
     // across output lines.
     for line in content.lines() {
-        term::color(color);
-        println!("{}", line);
+        println_color!(color, "{}", line);
     }
 
-    term::color(color);
-    dotted_line();
-    term::reset();
+    dotted_line(color);
+}
+
+fn dotted_line(color: Color) {
+    println_color!(color, "{}", "┈".repeat(60));
+}
+
+fn need_diff(expected: &str, actual: &str) -> bool {
+    let diffs = Changeset::new(expected, actual, "\n").diffs;
+
+    let lines_changed: usize = diffs
+        .iter()
+        .map(|d| match d {
+            Difference::Same(_) => 0,
+            Difference::Add(ref added) => added.split('\n').count(),
+            Difference::Rem(ref removed) => removed.split('\n').count(),
+        })
+        .sum();
+
+    let min_lines = min(expected.split('\n').count(), actual.split('\n').count()) as f64;
+    let diff_fraction = (lines_changed as f64) / min_lines;
+
+    // we print the diff only if diff lines count is 6 or less
+    // OR overall number of lines changed is 10% or less of
+    // `min(expected_lines, actual_lines)`
+
+    lines_changed <= 6 || diff_fraction <= 0.1
+}
+
+// github-like diff
+fn print_diff(diffs: Vec<Difference>) {
+    macro_rules! print_diff_snippet {
+        ($title:expr, $ty:ident, $color:expr, $diffs:expr) => {{
+            println_bold!($color, $title);
+            dotted_line($color);
+
+            for (i, chunk) in $diffs.iter().enumerate() {
+                match chunk {
+                    Difference::$ty(ref chunk) => {
+                        if i != 0 {
+                            print!(" ");
+                        }
+
+                        // LF symbols should not be colored
+                        let trimmed = chunk.trim_end_matches('\n');
+                        print_bg_color!($color, "{}", trimmed);
+                        print!("{}", "\n".repeat(chunk.len() - trimmed.len()));
+                    }
+
+                    Difference::Same(ref chunk) => {
+                        if i != 0 {
+                            print!(" ");
+                        }
+                        print_color!($color, "{}", chunk);
+                    }
+
+                    _ => {}
+                }
+            }
+
+            println!();
+            dotted_line($color);
+            println!();
+        }};
+    }
+
+    print_diff_snippet!("EXPECTED:", Rem, EXPECTED_COLOR, &diffs);
+    println!();
+    print_diff_snippet!("ACTUAL OUTPUT:", Add, ACTUAL_COLOR, &diffs);
+    println!();
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,7 +1,10 @@
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use lazy_static::lazy_static;
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream as Stream, WriteColor};
+use termcolor::{
+    Color::{self, White},
+    ColorChoice, ColorSpec, StandardStream as Stream, WriteColor,
+};
 
 lazy_static! {
     static ref TERM: Mutex<Stream> = Mutex::new(Stream::stderr(ColorChoice::Auto));
@@ -21,6 +24,10 @@ pub fn color(color: Color) {
 
 pub fn bold_color(color: Color) {
     let _ = lock().set_color(ColorSpec::new().set_bold(true).set_fg(Some(color)));
+}
+
+pub fn bg_color(color: Color) {
+    let _ = lock().set_color(ColorSpec::new().set_fg(Some(White)).set_bg(Some(color)));
 }
 
 pub fn reset() {


### PR DESCRIPTION
Closes #25 

Print diff of actual/expected mismatch. We print the diff only if one of the following is true:
- overall count of diff lines is 10% or less than `min(expected_lines, actual_lines)`
- overall count of diff lines is 6 or less. Without this condition there's no chance the diff would be printed on small `*.stderr` files