### PR TITLE
Normalize workspace-relative paths

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -204,6 +204,7 @@ impl Test {
             stderr
                 .replace(&name.0, "$CRATE")
                 .replace(project.source_dir.to_string_lossy().as_ref(), "$DIR")
+                .replace(project.workspace.to_string_lossy().as_ref(), "$WORKSPACE")
         });
 
         let check = match self.expected {


### PR DESCRIPTION
Fixes #28. Example message:

```console
error[E0277]: the trait bound `f64: std::convert::From<&str>` is not satisfied
 --> $DIR/test.rs:2:5
  |
2 |     b::f("");
  |     ^^^^ the trait `std::convert::From<&str>` is not implemented for `f64`
  |
 ::: $WORKSPACE/b/src/lib.rs:1:13
  |
1 | pub fn f<T: Into<f64>>(_: T) {}
  |             --------- required by this bound in `b::f`
  |
  = help: the following implementations were found:
            <f64 as std::convert::From<f32>>
            <f64 as std::convert::From<i16>>
            <f64 as std::convert::From<i32>>
            <f64 as std::convert::From<i8>>
          and 3 others
  = note: required because of the requirements on the impl of `std::convert::Into<f64>` for `&str`
```