### PR TITLE
Normalize separators in $WORKSPACE paths

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -99,6 +99,7 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
     }
 
     if line.trim_start().starts_with("::: ") {
+        let line = line.replace(context.workspace.to_string_lossy().as_ref(), "$WORKSPACE");
         return Some(line.replace('\\', "/"));
     }
 
@@ -140,7 +141,7 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
     let line = line
         .replace(context.krate, "$CRATE")
         .replace(context.source_dir.to_string_lossy().as_ref(), "$DIR")
-        .replace(&context.workspace.to_string_lossy().as_ref().replace('\\', "/"), "$WORKSPACE");
+        .replace(context.workspace.to_string_lossy().as_ref(), "$WORKSPACE");
 
     Some(line)
 }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -98,6 +98,10 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
         }
     }
 
+    if line.trim_start().starts_with("::: ") {
+        return Some(line.replace('\\', "/"));
+    }
+
     if line.starts_with("error: aborting due to ") {
         return None;
     }
@@ -134,9 +138,9 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
     }
 
     let line = line
-        .replace("$CRATE", context.krate)
-        .replace("$DIR", context.source_dir.to_string_lossy().as_ref())
-        .replace("$WORKSPACE", context.workspace.to_string_lossy().as_ref());
+        .replace(context.krate, "$CRATE")
+        .replace(context.source_dir.to_string_lossy().as_ref(), "$DIR")
+        .replace(&context.workspace.to_string_lossy().as_ref().replace('\\', "/"), "$WORKSPACE");
 
     Some(line)
 }


### PR DESCRIPTION
Fixes #30. All lines beginning with `"::: "` have their paths normalized to use Unix path separators, and the `$WORKSPACE` normalization takes this into account.