### PR TITLE
Dependency cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-termcolor = "1.0"
+termcolor = "1.0.4"
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ lazy_static = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0.4"
-toml = "0.5"
+toml = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 glob = "0.3"
 lazy_static = "1.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0.4"
 toml = "0.5.2"


### PR DESCRIPTION
---
Is it worth trying to find the actual minimum version of `serde` for `toml-rs`? See alexcrichton/toml-rs@381d020563ac3c1421c77cd5799a4b78462767b7 for details on that change.