### PR TITLE
Highlight diffs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ travis-ci = { repository = "dtolnay/trybuild" }
 
 [features]
 default = ["diff"]
-diff = ["diffr-lib"]
+diff = ["dissimilar"]
 
 [dependencies]
-diffr-lib = { version = "=0.1.3", optional = true }
+dissimilar = { version = "1.0", optional = true }
 glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/trybuild" }
 
 [dependencies]
-diffr-lib = { version = "=0.1.2", git = "https://github.com/mookid/diffr", branch = "best-lcs" }
+diffr-lib = "=0.1.3"
 glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/trybuild" }
 
 [dependencies]
+diffr-lib = "=0.1.2"
 glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/trybuild" }
 
 [dependencies]
-diffr-lib = "=0.1.2"
+diffr-lib = { version = "=0.1.2", git = "https://github.com/mookid/diffr", branch = "best-lcs" }
 glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/trybuild" }
 
 [features]
+# Experimental: highlight the diff between the expected and actual compiler
+# output. Currently unix-only. If you test this out, please provide any feedback
+# in https://github.com/dtolnay/trybuild/issues/41.
 diff = ["dissimilar"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 travis-ci = { repository = "dtolnay/trybuild" }
 
 [features]
-default = ["diff"]
 diff = ["dissimilar"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,12 @@ readme = "README.md"
 [badges]
 travis-ci = { repository = "dtolnay/trybuild" }
 
+[features]
+default = ["diff"]
+diff = ["diffr-lib"]
+
 [dependencies]
-diffr-lib = "=0.1.3"
+diffr-lib = { version = "=0.1.3", optional = true }
 glob = "0.3"
 lazy_static = "1.3"
 serde = { version = "1.0.103", features = ["derive"] }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,112 @@
+use diffr_lib::{diff, tokenize, DiffInput, HashedSpan, Snake, Tokenization};
+use std::cmp;
+use std::iter::Peekable;
+use std::slice;
+
+pub struct Diff<'a> {
+    pub worth_printing: bool,
+    expected: &'a str,
+    expected_tokens: Vec<HashedSpan>,
+    actual: &'a str,
+    actual_tokens: Vec<HashedSpan>,
+    common: Vec<Snake>,
+}
+
+impl<'a> Diff<'a> {
+    pub fn compute(expected: &'a str, actual: &'a str) -> Self {
+        let mut actual_tokens = Vec::new();
+        tokenize(actual.as_bytes(), 0, &mut actual_tokens);
+        let added = Tokenization::new(actual.as_bytes(), &actual_tokens);
+
+        let mut expected_tokens = Vec::new();
+        tokenize(expected.as_bytes(), 0, &mut expected_tokens);
+        let removed = Tokenization::new(expected.as_bytes(), &expected_tokens);
+
+        let input = DiffInput { added, removed };
+        let mut scratch = Vec::new();
+        let mut common = Vec::new();
+        diff(&input, &mut scratch, &mut common);
+
+        let min_len = cmp::max(expected_tokens.len(), actual_tokens.len());
+        let common_len = common.iter().map(|snake| snake.len).sum::<isize>() as usize;
+        let worth_printing = common_len / 4 >= min_len / 5;
+
+        Diff {
+            worth_printing,
+            expected,
+            expected_tokens,
+            actual,
+            actual_tokens,
+            common,
+        }
+    }
+
+    pub fn iter(&self, input: &str) -> Iter {
+        if input == self.expected {
+            Iter {
+                pos: 0,
+                input: self.expected,
+                tokens: &self.expected_tokens,
+                common: self.common.iter().peekable(),
+                token_index: |snake| snake.x0,
+            }
+        } else if input == self.actual {
+            Iter {
+                pos: 0,
+                input: self.actual,
+                tokens: &self.actual_tokens,
+                common: self.common.iter().peekable(),
+                token_index: |snake| snake.y0,
+            }
+        } else {
+            panic!("unrecognized input");
+        }
+    }
+}
+
+pub struct Iter<'a> {
+    pos: usize,
+    input: &'a str,
+    tokens: &'a [HashedSpan],
+    common: Peekable<slice::Iter<'a, Snake>>,
+    token_index: fn(&Snake) -> isize,
+}
+
+pub enum Chunk<'a> {
+    Common(&'a str),
+    Unique(&'a str),
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Chunk<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.common.peek() {
+            Some(common) => {
+                let index = (self.token_index)(common);
+                let begin = &self.tokens[index as usize];
+                if self.pos < begin.lo {
+                    let chunk = &self.input[self.pos..begin.lo];
+                    self.pos = begin.lo;
+                    Some(Chunk::Unique(chunk))
+                } else {
+                    let index = (self.token_index)(common) + common.len - 1;
+                    let end = &self.tokens[index as usize];
+                    let chunk = &self.input[begin.lo..end.hi];
+                    self.common.next().unwrap();
+                    self.pos = end.hi;
+                    Some(Chunk::Common(chunk))
+                }
+            }
+            None => {
+                if self.pos < self.input.len() {
+                    let chunk = &self.input[self.pos..];
+                    self.pos = self.input.len();
+                    Some(Chunk::Unique(chunk))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,7 +5,7 @@ pub enum Render<'a> {
     Unique(&'a str),
 }
 
-#[cfg(feature = "diff")]
+#[cfg(all(feature = "diff", not(windows)))]
 mod r#impl {
     use super::Render;
     use dissimilar::Chunk;
@@ -62,7 +62,7 @@ mod r#impl {
     }
 }
 
-#[cfg(not(feature = "diff"))]
+#[cfg(any(not(feature = "diff"), windows))]
 mod r#impl {
     use super::Render;
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,112 +1,141 @@
-use diffr_lib::{diff, tokenize, DiffInput, HashedSpan, Snake, Tokenization};
-use std::cmp;
-use std::iter::Peekable;
-use std::slice;
-
-pub struct Diff<'a> {
-    pub worth_printing: bool,
-    expected: &'a str,
-    expected_tokens: Vec<HashedSpan>,
-    actual: &'a str,
-    actual_tokens: Vec<HashedSpan>,
-    common: Vec<Snake>,
-}
-
-impl<'a> Diff<'a> {
-    pub fn compute(expected: &'a str, actual: &'a str) -> Self {
-        let mut actual_tokens = Vec::new();
-        tokenize(actual.as_bytes(), 0, &mut actual_tokens);
-        let added = Tokenization::new(actual.as_bytes(), &actual_tokens);
-
-        let mut expected_tokens = Vec::new();
-        tokenize(expected.as_bytes(), 0, &mut expected_tokens);
-        let removed = Tokenization::new(expected.as_bytes(), &expected_tokens);
-
-        let input = DiffInput { added, removed };
-        let mut scratch = Vec::new();
-        let mut common = Vec::new();
-        diff(&input, &mut scratch, &mut common);
-
-        let min_len = cmp::max(expected_tokens.len(), actual_tokens.len());
-        let common_len = common.iter().map(|snake| snake.len).sum::<isize>() as usize;
-        let worth_printing = common_len / 4 >= min_len / 5;
-
-        Diff {
-            worth_printing,
-            expected,
-            expected_tokens,
-            actual,
-            actual_tokens,
-            common,
-        }
-    }
-
-    pub fn iter(&self, input: &str) -> Iter {
-        if input == self.expected {
-            Iter {
-                pos: 0,
-                input: self.expected,
-                tokens: &self.expected_tokens,
-                common: self.common.iter().peekable(),
-                token_index: |snake| snake.x0,
-            }
-        } else if input == self.actual {
-            Iter {
-                pos: 0,
-                input: self.actual,
-                tokens: &self.actual_tokens,
-                common: self.common.iter().peekable(),
-                token_index: |snake| snake.y0,
-            }
-        } else {
-            panic!("unrecognized input");
-        }
-    }
-}
-
-pub struct Iter<'a> {
-    pos: usize,
-    input: &'a str,
-    tokens: &'a [HashedSpan],
-    common: Peekable<slice::Iter<'a, Snake>>,
-    token_index: fn(&Snake) -> isize,
-}
+pub use self::r#impl::Diff;
 
 pub enum Chunk<'a> {
     Common(&'a str),
     Unique(&'a str),
 }
 
-impl<'a> Iterator for Iter<'a> {
-    type Item = Chunk<'a>;
+#[cfg(feature = "diff")]
+mod r#impl {
+    use super::Chunk;
+    use diffr_lib::{diff, tokenize, DiffInput, HashedSpan, Snake, Tokenization};
+    use std::cmp;
+    use std::iter::Peekable;
+    use std::slice;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.common.peek() {
-            Some(common) => {
-                let index = (self.token_index)(common);
-                let begin = &self.tokens[index as usize];
-                if self.pos < begin.lo {
-                    let chunk = &self.input[self.pos..begin.lo];
-                    self.pos = begin.lo;
-                    Some(Chunk::Unique(chunk))
-                } else {
-                    let index = (self.token_index)(common) + common.len - 1;
-                    let end = &self.tokens[index as usize];
-                    let chunk = &self.input[begin.lo..end.hi];
-                    self.common.next().unwrap();
-                    self.pos = end.hi;
-                    Some(Chunk::Common(chunk))
+    pub struct Diff<'a> {
+        pub worth_printing: bool,
+        expected: &'a str,
+        expected_tokens: Vec<HashedSpan>,
+        actual: &'a str,
+        actual_tokens: Vec<HashedSpan>,
+        common: Vec<Snake>,
+    }
+
+    impl<'a> Diff<'a> {
+        pub fn compute(expected: &'a str, actual: &'a str) -> Self {
+            let mut actual_tokens = Vec::new();
+            tokenize(actual.as_bytes(), 0, &mut actual_tokens);
+            let added = Tokenization::new(actual.as_bytes(), &actual_tokens);
+
+            let mut expected_tokens = Vec::new();
+            tokenize(expected.as_bytes(), 0, &mut expected_tokens);
+            let removed = Tokenization::new(expected.as_bytes(), &expected_tokens);
+
+            let input = DiffInput { added, removed };
+            let mut scratch = Vec::new();
+            let mut common = Vec::new();
+            diff(&input, &mut scratch, &mut common);
+
+            let min_len = cmp::max(expected_tokens.len(), actual_tokens.len());
+            let common_len = common.iter().map(|snake| snake.len).sum::<isize>() as usize;
+            let worth_printing = common_len / 4 >= min_len / 5;
+
+            Diff {
+                worth_printing,
+                expected,
+                expected_tokens,
+                actual,
+                actual_tokens,
+                common,
+            }
+        }
+
+        pub fn iter(&self, input: &str) -> Iter {
+            if input == self.expected {
+                Iter {
+                    pos: 0,
+                    input: self.expected,
+                    tokens: &self.expected_tokens,
+                    common: self.common.iter().peekable(),
+                    token_index: |snake| snake.x0,
+                }
+            } else if input == self.actual {
+                Iter {
+                    pos: 0,
+                    input: self.actual,
+                    tokens: &self.actual_tokens,
+                    common: self.common.iter().peekable(),
+                    token_index: |snake| snake.y0,
+                }
+            } else {
+                panic!("unrecognized input");
+            }
+        }
+    }
+
+    pub struct Iter<'a> {
+        pos: usize,
+        input: &'a str,
+        tokens: &'a [HashedSpan],
+        common: Peekable<slice::Iter<'a, Snake>>,
+        token_index: fn(&Snake) -> isize,
+    }
+
+    impl<'a> Iterator for Iter<'a> {
+        type Item = Chunk<'a>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.common.peek() {
+                Some(common) => {
+                    let index = (self.token_index)(common);
+                    let begin = &self.tokens[index as usize];
+                    if self.pos < begin.lo {
+                        let chunk = &self.input[self.pos..begin.lo];
+                        self.pos = begin.lo;
+                        Some(Chunk::Unique(chunk))
+                    } else {
+                        let index = (self.token_index)(common) + common.len - 1;
+                        let end = &self.tokens[index as usize];
+                        let chunk = &self.input[begin.lo..end.hi];
+                        self.common.next().unwrap();
+                        self.pos = end.hi;
+                        Some(Chunk::Common(chunk))
+                    }
+                }
+                None => {
+                    if self.pos < self.input.len() {
+                        let chunk = &self.input[self.pos..];
+                        self.pos = self.input.len();
+                        Some(Chunk::Unique(chunk))
+                    } else {
+                        None
+                    }
                 }
             }
-            None => {
-                if self.pos < self.input.len() {
-                    let chunk = &self.input[self.pos..];
-                    self.pos = self.input.len();
-                    Some(Chunk::Unique(chunk))
-                } else {
-                    None
-                }
+        }
+    }
+}
+
+#[cfg(not(feature = "diff"))]
+mod r#impl {
+    use super::Chunk;
+
+    pub struct Diff {
+        pub worth_printing: bool,
+    }
+
+    impl Diff {
+        pub fn compute(_expected: &str, _actual: &str) -> Self {
+            Diff {
+                worth_printing: false,
             }
+        }
+
+        pub fn iter(&self, _input: &str) -> &[Chunk] {
+            let _ = Chunk::Common;
+            let _ = Chunk::Unique;
+            &[]
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ mod path;
 
 mod cargo;
 mod dependencies;
+mod diff;
 mod env;
 mod error;
 mod features;

--- a/src/message.rs
+++ b/src/message.rs
@@ -130,14 +130,19 @@ pub(crate) fn mismatch(expected: &str, actual: &str) {
     println!("mismatch");
     term::reset();
     println!();
-    let diff = Diff::compute(expected, actual);
+    let diff = if expected.len() + actual.len() <= 2048 {
+        // We don't yet trust the dissimilar crate to work well on large inputs.
+        Some(Diff::compute(expected, actual))
+    } else {
+        None
+    };
     term::bold_color(Blue);
     println!("EXPECTED:");
-    snippet_diff(Blue, expected, Some(&diff));
+    snippet_diff(Blue, expected, diff.as_ref());
     println!();
     term::bold_color(Red);
     println!("ACTUAL OUTPUT:");
-    snippet_diff(Red, actual, Some(&diff));
+    snippet_diff(Red, actual, diff.as_ref());
     println!();
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::normalize;
 use crate::term;
 
+use std::panic;
 use std::path::Path;
 use std::process::Output;
 
@@ -131,8 +132,9 @@ pub(crate) fn mismatch(expected: &str, actual: &str) {
     term::reset();
     println!();
     let diff = if expected.len() + actual.len() <= 2048 {
-        // We don't yet trust the dissimilar crate to work well on large inputs.
-        Some(Diff::compute(expected, actual))
+        // We don't yet trust the dissimilar crate to work well on large inputs
+        // or non-ascii inputs.
+        panic::catch_unwind(|| Diff::compute(expected, actual)).ok()
     } else {
         None
     };

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::normalize;
 use crate::term;
 
+use std::env;
 use std::path::Path;
 use std::process::Output;
 
@@ -130,7 +131,12 @@ pub(crate) fn mismatch(expected: &str, actual: &str) {
     println!("mismatch");
     term::reset();
     println!();
-    let diff = Diff::compute(expected, actual);
+    let diff = if env::var_os("TERM").map_or(true, |term| term == "dumb") {
+        // No diff in dumb terminal or when TERM is unset.
+        None
+    } else {
+        Diff::compute(expected, actual)
+    };
     term::bold_color(Blue);
     println!("EXPECTED:");
     snippet_diff(Blue, expected, diff.as_ref());

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,7 @@
 use termcolor::Color::{self, *};
 
 use super::{Expected, Test};
-use crate::diff::{Chunk, Diff};
+use crate::diff::{Diff, Render};
 use crate::error::Error;
 use crate::normalize;
 use crate::term;
@@ -220,11 +220,11 @@ fn snippet_diff(color: Color, content: &str, diff: Option<&Diff>) {
         Some(diff) if diff.worth_printing => {
             for chunk in diff.iter(content) {
                 match chunk {
-                    Chunk::Common(s) => {
+                    Render::Common(s) => {
                         term::color(color);
                         print!("{}", s);
                     }
-                    Chunk::Unique(s) => {
+                    Render::Unique(s) => {
                         term::bold_color(color);
                         print!("\x1B[7m{}", s);
                     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,7 +6,6 @@ use crate::error::Error;
 use crate::normalize;
 use crate::term;
 
-use std::panic;
 use std::path::Path;
 use std::process::Output;
 
@@ -131,13 +130,7 @@ pub(crate) fn mismatch(expected: &str, actual: &str) {
     println!("mismatch");
     term::reset();
     println!();
-    let diff = if expected.len() + actual.len() <= 2048 {
-        // We don't yet trust the dissimilar crate to work well on large inputs
-        // or non-ascii inputs.
-        panic::catch_unwind(|| Diff::compute(expected, actual)).ok()
-    } else {
-        None
-    };
+    let diff = Diff::compute(expected, actual);
     term::bold_color(Blue);
     println!("EXPECTED:");
     snippet_diff(Blue, expected, diff.as_ref());
@@ -224,7 +217,7 @@ fn snippet_diff(color: Color, content: &str, diff: Option<&Diff>) {
     dotted_line();
 
     match diff {
-        Some(diff) if diff.worth_printing => {
+        Some(diff) => {
             for chunk in diff.iter(content) {
                 match chunk {
                     Render::Common(s) => {
@@ -238,7 +231,7 @@ fn snippet_diff(color: Color, content: &str, diff: Option<&Diff>) {
                 }
             }
         }
-        _ => print!("{}", content),
+        None => print!("{}", content),
     }
 
     term::color(color);


### PR DESCRIPTION
Requires an opt-in for now (`cargo test --features trybuild/diff`).

Currently unix-only. We will need to look into how to get highlighted background color reliably on Windows terminals, and ideally implement support for it in https://github.com/BurntSushi/termcolor.

The diff is backed by https://github.com/dtolnay/dissimilar which is intended to produce human readable diffs with less noise than raw Myers' algorithm.

The intended output looks like:

<p align="center"><img src="https://user-images.githubusercontent.com/1940490/71450848-e365b700-2737-11ea-9656-116ef72c01b9.png" width="80%"></p>

Tracking issue: #41
Closes #25. Closes #26. Closes #27.