### PR TITLE
Define cfg(trybuild) when compiling

### DIFF
--- a/src/rustflags.rs
+++ b/src/rustflags.rs
@@ -5,7 +5,7 @@ const RUSTFLAGS: &str = "RUSTFLAGS";
 const IGNORED_LINTS: &[&str] = &["dead_code"];
 
 pub fn make_vec() -> Vec<&'static str> {
-    let mut rustflags = Vec::new();
+    let mut rustflags = vec!["--cfg", "trybuild"];
 
     for &lint in IGNORED_LINTS {
         rustflags.push("-A");


### PR DESCRIPTION
This allows build scripts (via `cfg!(trybuild)`) and libraries (via `#[cfg(trybuild)]`) to omit parts that are unneeded for the ui tests.