### PR TITLE
Always execute cargo with the --offline flag

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -24,6 +24,7 @@ fn cargo(project: &Project) -> Command {
         "CARGO_TARGET_DIR",
         path!(project.target_dir / "tests" / "target"),
     );
+    cmd.arg("--offline");
     rustflags::set_env(&mut cmd);
     cmd
 }


### PR DESCRIPTION
The instance of cargo that is launched by trybuild always has a subset of the dependencies of the current test run, meaning the should already be in cargo's cache.

Resolves #50.