### PR TITLE
Force lockfile regeneration

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -31,6 +31,15 @@ fn cargo(project: &Project) -> Command {
 
 pub fn build_dependencies(project: &Project) -> Result<()> {
     let status = cargo(project)
+        .arg("generate-lockfile")
+        .status()
+        .map_err(Error::Cargo)?;
+
+    if !status.success() {
+        return Err(Error::CargoFail)
+    }
+
+    let status = cargo(project)
         .arg(if project.has_pass { "build" } else { "check" })
         .arg("--bin")
         .arg(&project.name)


### PR DESCRIPTION
Rel #53.

Runs [`cargo generate-lockfile`](https://doc.rust-lang.org/cargo/commands/cargo-generate-lockfile.html) before building the generated `trybuild` runner crate.

It is run with `--offline` so forces resolutions of locally available dependencies, which should be the same set of dependencies resolved and downloaded for the outer crate.

