### PR TITLE
Add compile_fail_quiet method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ A compile\_fail test that fails to fail to compile is also a failure.
 
 <br>
 
+## Asserting Compile-fail tests
+
+While generally it is desirable to check for particular error messages, it is
+sometimes nice to simply check whether or not a particular test file compiles
+at all, ignoring the particular error. These tests look like this:
+
+```rust
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.assert_compile_fail("tests/ui/*.rs");
+}
+```
+
+The test can be run with `cargo test`. It will individually compile each of the
+source files matching the glob pattern, and expect them to fail to compile.
+Unlike standard `compile_fail` tests, no `*.stderr` files are required or consulted.
+
+Dependencies listed under `[dev-dependencies]` in the project's Cargo.toml are
+accessible from within the test cases.
+
 ## Pass tests
 
 The same test harness is able to run tests that are expected to pass, too.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,7 @@ struct Test {
 enum Expected {
     Pass,
     CompileFail,
+    CompileFailQuiet,
 }
 
 impl TestCases {
@@ -252,6 +253,7 @@ impl TestCases {
         }
     }
 
+    /// Assert that these test files compile successfully.
     pub fn pass<P: AsRef<Path>>(&self, path: P) {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
@@ -259,10 +261,21 @@ impl TestCases {
         });
     }
 
+    /// Assert that these test files fail to compile, with particular error messages.
+    ///
+    /// The error messages are collected from parallel `*.stderr` files.
     pub fn compile_fail<P: AsRef<Path>>(&self, path: P) {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
             expected: Expected::CompileFail,
+        });
+    }
+
+    /// Assert that these test files fail to compile, but do not check error messages.
+    pub fn assert_compile_fail<P: AsRef<Path>>(&self, path: P) {
+        self.runner.borrow_mut().tests.push(Test {
+            path: path.as_ref().to_owned(),
+            expected: Expected::CompileFailQuiet,
         });
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -72,7 +72,7 @@ pub(crate) fn begin_test(test: &Test, show_expected: bool) {
     if show_expected {
         match test.expected {
             Expected::Pass => print!(" [should pass]"),
-            Expected::CompileFail => print!(" [should fail to compile]"),
+            Expected::CompileFail | Expected::CompileFailQuiet => print!(" [should fail to compile]"),
         }
     }
 


### PR DESCRIPTION
This method ensures that a set of tests fails to compile, but skips
all the checking against particular error messages.

Closes #56. 