### PR TITLE
Pass features when building dependencies

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -36,6 +36,7 @@ pub fn build_dependencies(project: &Project) -> Result<()> {
 
     let status = cargo(project)
         .arg(if project.has_pass { "build" } else { "check" })
+        .args(features(project))
         .arg("--bin")
         .arg(&project.name)
         .status()


### PR DESCRIPTION
I don't know whether leaving this out was an oversight or not, but it is
definitely required for my use case (my crate doesn't build without one
of a set of features being passed). I also can't see a reason why the
features shouldn't be passed here.