### PR TITLE
normalize dir seperators in types

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -43,6 +43,7 @@ pub fn diagnostics(output: Vec<u8>, context: Context) -> Variations {
         StripForMoreInformation,
         StripForMoreInformation2,
         DirBackslash,
+        TypeDirBackslash,
         TrimEnd,
         RustLib,
     ]
@@ -75,6 +76,7 @@ enum Normalization {
     StripForMoreInformation,
     StripForMoreInformation2,
     DirBackslash,
+    TypeDirBackslash,
     TrimEnd,
     RustLib,
 }
@@ -158,6 +160,15 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
         // https://github.com/dtolnay/trybuild/issues/66
         let source_dir_with_backslash = context.source_dir.to_string_lossy().into_owned() + "\\";
         line = line.replace(&source_dir_with_backslash, "$DIR/");
+    }
+
+    if normalization >= TypeDirBackslash {
+        if line
+            .trim_start()
+            .starts_with("= note: required because it appears within the type")
+        {
+            line = line.replace('\\', "/");
+        }
     }
 
     if normalization >= TrimEnd {

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -43,9 +43,9 @@ pub fn diagnostics(output: Vec<u8>, context: Context) -> Variations {
         StripForMoreInformation,
         StripForMoreInformation2,
         DirBackslash,
-        TypeDirBackslash,
         TrimEnd,
         RustLib,
+        TypeDirBackslash,
     ]
     .iter()
     .map(|normalization| apply(&from_bytes, *normalization, context))
@@ -76,9 +76,9 @@ enum Normalization {
     StripForMoreInformation,
     StripForMoreInformation2,
     DirBackslash,
-    TypeDirBackslash,
     TrimEnd,
     RustLib,
+    TypeDirBackslash,
 }
 
 use self::Normalization::*;
@@ -162,6 +162,10 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
         line = line.replace(&source_dir_with_backslash, "$DIR/");
     }
 
+    if normalization >= TrimEnd {
+        line.truncate(line.trim_end().len());
+    }
+
     if normalization >= TypeDirBackslash {
         if line
             .trim_start()
@@ -169,10 +173,6 @@ fn filter(line: &str, normalization: Normalization, context: Context) -> Option<
         {
             line = line.replace('\\', "/");
         }
-    }
-
-    if normalization >= TrimEnd {
-        line.truncate(line.trim_end().len());
     }
 
     line = line

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -18,4 +18,5 @@ fn test() {
     t.pass("tests/ui/run-fail.rs");
     t.pass("tests/ui/run-pass-9.rs");
     t.compile_fail("tests/ui/compile-fail-2.rs");
+    t.compile_fail("tests/ui/compile-fail-3.rs");
 }

--- a/tests/ui/compile-fail-3.rs
+++ b/tests/ui/compile-fail-3.rs
@@ -1,0 +1,10 @@
+use std::ptr;
+use std::thread;
+
+fn main() {
+    let x = ptr::null_mut();
+
+    thread::spawn(|| {
+        println!("{:?}", x)
+    });
+}

--- a/tests/ui/compile-fail-3.stderr
+++ b/tests/ui/compile-fail-3.stderr
@@ -1,0 +1,9 @@
+error[E0277]: `*mut _` cannot be shared between threads safely
+   --> $DIR/compile-fail-3.rs:7:5
+    |
+7   |     thread::spawn(|| {
+    |     ^^^^^^^^^^^^^ `*mut _` cannot be shared between threads safely
+    |
+    = help: the trait `std::marker::Sync` is not implemented for `*mut _`
+    = note: required because of the requirements on the impl of `std::marker::Send` for `&*mut _`
+    = note: required because it appears within the type `[closure@$DIR/tests/ui/compile-fail-3.rs:7:19: 9:6 x:&*mut _]`


### PR DESCRIPTION
Rust anonymous closure types include the path to the position in the file where the closure was defined. This results in different output on windows compared to linux and mac. This patch looks for lines starting with "= note: required because it appears within the type", and replaces all '\' with '/' in order to be cross platform.

I'm not completely confident about how we're supposed to order the different normalization schemes, but this placement seems to work in my local testing.