### PR TITLE
Recognize new standard library directory structure

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -149,6 +149,10 @@ impl<'a> Filter<'a> {
                     // ::: $RUST/src/libstd/net/ip.rs:83:1
                     line.replace_range(line.find("::: ").unwrap() + 4..pos + 17, "$RUST");
                     other_crate = true;
+                } else if let Some(pos) = line.find("/rustlib/src/rust/library/") {
+                    // ::: $RUST/std/src/net/ip.rs:83:1
+                    line.replace_range(line.find("::: ").unwrap() + 4..pos + 25, "$RUST");
+                    other_crate = true;
                 }
             }
             if other_crate && self.normalization >= WorkspaceLines {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -58,6 +58,13 @@ error[E0599]: no method named `quote_into_iter` found for struct `std::net::Ipv4
    | -------------------
    | |
    | doesn't satisfy `std::net::Ipv4Addr: quote::to_tokens::ToTokens`
+   |
+  ::: /rustlib/src/rust/library/std/src/net/ip.rs:83:1
+   |
+83 | pub struct Ipv4Addr {
+   | -------------------
+   | |
+   | doesn't satisfy `std::net::Ipv4Addr: quote::to_tokens::ToTokens`
 " "
 error[E0599]: no method named `quote_into_iter` found for struct `std::net::Ipv4Addr` in the current scope
   --> $DIR/not-repeatable.rs:6:13
@@ -66,6 +73,13 @@ error[E0599]: no method named `quote_into_iter` found for struct `std::net::Ipv4
    |             ^^^^^^^^^^^^^^^^^^ method not found in `std::net::Ipv4Addr`
    |
   ::: $RUST/src/libstd/net/ip.rs
+   |
+   | pub struct Ipv4Addr {
+   | -------------------
+   | |
+   | doesn't satisfy `std::net::Ipv4Addr: quote::to_tokens::ToTokens`
+   |
+  ::: $RUST/std/src/net/ip.rs
    |
    | pub struct Ipv4Addr {
    | -------------------


### PR DESCRIPTION
Updates to recognize the library paths introduced in https://github.com/rust-lang/rust/pull/73265.

- Before: */toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/net/ip.rs*
- After: */toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/net/ip.rs*