### PR TITLE
Propagate --target flag from cargo test invocation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+fn main() -> io::Result<()> {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let target = env::var("TARGET").ok();
+    let path = Path::new(&out_dir).join("target.rs");
+    let value = match target {
+        Some(target) => format!("Some({:?})", target),
+        None => "None".to_owned(),
+    };
+    let content = format!("const TARGET: Option<&'static str> = {};", value);
+    fs::write(path, content)
+}

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -34,6 +34,7 @@ pub fn build_dependencies(project: &Project) -> Result<()> {
 
     let status = cargo(project)
         .arg(if project.has_pass { "build" } else { "check" })
+        .args(target())
         .arg("--bin")
         .arg(&project.name)
         .args(features(project))
@@ -59,6 +60,7 @@ pub fn build_test(project: &Project, name: &Name) -> Result<Output> {
 
     cargo(project)
         .arg(if project.has_pass { "build" } else { "check" })
+        .args(target())
         .arg("--bin")
         .arg(name)
         .args(features(project))
@@ -71,6 +73,7 @@ pub fn build_test(project: &Project, name: &Name) -> Result<Output> {
 pub fn run_test(project: &Project, name: &Name) -> Result<Output> {
     cargo(project)
         .arg("run")
+        .args(target())
         .arg("--bin")
         .arg(name)
         .args(features(project))
@@ -101,6 +104,13 @@ fn features(project: &Project) -> Vec<String> {
             "--features".to_owned(),
             features.join(","),
         ],
+        None => vec![],
+    }
+}
+
+fn target() -> Vec<&'static str> {
+    match crate::TARGET {
+        Some(target) => vec!["--target", target],
         None => vec![],
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,8 @@ mod normalize;
 mod run;
 mod rustflags;
 
+include!(concat!(env!("OUT_DIR"), "/target.rs"));
+
 use std::cell::RefCell;
 use std::panic::RefUnwindSafe;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Closes #61.

Tested with `cargo test --target x86_64-unknown-linux-gnu` inside a crate that has `[build] target = "thumbv7m-none-eabi"` in .cargo/config.