### PR TITLE
Support including extra files in the test project

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ pub struct TestCases {
 #[derive(Debug)]
 struct Runner {
     tests: Vec<Test>,
+    files: Vec<PathBuf>,
 }
 
 #[derive(Clone, Debug)]
@@ -261,7 +262,10 @@ impl TestCases {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         TestCases {
-            runner: RefCell::new(Runner { tests: Vec::new() }),
+            runner: RefCell::new(Runner {
+                tests: Vec::new(),
+                files: Vec::new(),
+            }),
         }
     }
 
@@ -277,6 +281,13 @@ impl TestCases {
             path: path.as_ref().to_owned(),
             expected: Expected::CompileFail,
         });
+    }
+
+    pub fn extra<P: AsRef<Path>>(&self, path: P) {
+        self.runner
+            .borrow_mut()
+            .files
+            .push(path.as_ref().to_owned());
     }
 }
 

--- a/tests/res/content.txt
+++ b/tests/res/content.txt
@@ -1,0 +1,1 @@
+hello world

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test() {
     let t = trybuild::TestCases::new();
+    t.extra("tests/res/content.txt");
     t.pass("tests/ui/run-pass-0.rs");
     t.pass("tests/ui/print-stdout.rs");
     t.pass("tests/ui/run-pass-1.rs");
@@ -12,6 +13,7 @@ fn test() {
     t.pass("tests/ui/run-pass-5.rs");
     t.pass("tests/ui/compile-fail-0.rs");
     t.pass("tests/ui/run-pass-6.rs");
+    t.pass("tests/ui/read-file.rs");
     t.pass("tests/ui/run-pass-7.rs");
     t.pass("tests/ui/run-pass-8.rs");
     t.compile_fail("tests/ui/compile-fail-1.rs");

--- a/tests/ui/read-file.rs
+++ b/tests/ui/read-file.rs
@@ -1,0 +1,7 @@
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let file = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/res/content.txt");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello world");
+}


### PR DESCRIPTION
This solves #95, but TBH personally I don't quite like this, especially the delete and link bit.

I'm thinking that it would be great if the whole test project can be put in a FUSE which is backed by the actual project directory with just the `Cargo.toml` and `Cargo.lock` overridden. But there doesn't seem to be a cross-platform FUSE implementation, and it generally requires installing extra libraries as well :disappointed: 

WDYT?