### PR TITLE
Use the `Cargo.lock` from the workspace

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -30,8 +30,6 @@ fn cargo(project: &Project) -> Command {
 }
 
 pub fn build_dependencies(project: &Project) -> Result<()> {
-    let _ = cargo(project).arg("generate-lockfile").status();
-
     let status = cargo(project)
         .arg(if project.has_pass { "build" } else { "check" })
         .args(target())

--- a/src/run.rs
+++ b/src/run.rs
@@ -111,6 +111,20 @@ impl Runner {
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
         fs::write(path!(project.dir / "main.rs"), b"fn main() {}\n")?;
 
+        let workspace_cargo_lock = path!(project.workspace / "Cargo.lock");
+
+        if workspace_cargo_lock.exists() {
+            fs::copy(
+                workspace_cargo_lock,
+                path!(project.dir / "Cargo.lock"),
+            )?;
+        } else {
+            message::warnings(&format!(
+                "Could not find `Cargo.lock` in workspace, searched at `{}`",
+                workspace_cargo_lock.display(),
+            ));
+        }
+
         cargo::build_dependencies(&project)?;
 
         Ok(project)


### PR DESCRIPTION
This changes the way trybuild is generating the `Cargo.lock`. Instead of
generating a fresh `Cargo.lock`, it takes the `Cargo.lock` of the
workspace as "input". This should prevent compile problems because crate
patch versions are bumped on crates.io, but cargo fails to resolve a
proper `Cargo.lock` file. By using the workspace `Cargo.lock` we can be
sure that a working `Cargo.lock` file is used.

Fixes: https://github.com/dtolnay/trybuild/issues/53