### PR TITLE
Ignored patch fields leads to Cargo issues

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -140,6 +140,8 @@ pub struct Patch {
     pub git: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    #[serde(flatten)]
+    pub rest: Map<String, Value>,
 }
 
 fn get_true() -> bool {


### PR DESCRIPTION
It seems like we are ignoring certain fields from `patch` blocks from the workspace .toml

According to the [cargo docs](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) each patch line has the same spec as a normal dependency line (with fields like version, registry, etc.)

This change captures the unused fields and serializes them to avoid Cargo issues during test runs