### PR TITLE
[sccache compat] work well with sccache

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -3,9 +3,9 @@ use crate::manifest::Name;
 use crate::run::Project;
 use crate::rustflags;
 use serde::Deserialize;
-use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
+use std::{env::var, fs};
 
 #[derive(Deserialize)]
 pub struct Metadata {
@@ -14,7 +14,7 @@ pub struct Metadata {
 }
 
 fn raw_cargo() -> Command {
-    Command::new(option_env!("CARGO").unwrap_or("cargo"))
+    Command::new(var("CARGO").unwrap_or("cargo".to_string()))
 }
 
 fn cargo(project: &Project) -> Command {


### PR DESCRIPTION
At diem/diem we use sccache to speed up our builds in CI.

Sccache tracks CARGO_* environment variables, but not CARGO itself.   I think it's an open question as to what is a consistent and correct approach to hand all environment variables, who's answer will involve rustc build dep files, but I think CARGO locations could and probably should be ignored.

HISTORY:
1. We were using circleci and migrating to gha actions.
2. Circleci environment and gha environment differed in that cargo locations (long story related to docker handling in both environments)
3. Only trybuld test would fail when using a binary pulled from the cache with incorrect embedded cargo location, a race condition between the two CIs during the transition.

Since cargo always sets the CARGO env it should be safe to move the look up to runtime.   If an IDE runs a test directly it should likely also be setting the CARGO env -- this leaves the case someone attempting to call the test executable directly, at which point falling back to the path seems reasonable.   Perhaps with a warning?

I'll independently of this look to have std Command print the fully path to the executable if it's not found (right now the error message doesn't help determine which cargo we're trying to use, on the PATH, or via the CARGO env variable.

Another option would be to inline with a env, but check that an executable exists at that location, then fall back to var, and then finally to path.  More consistent with current behavior but more complex.   Thoughts?


