### PR TITLE
Runners use separate directories to allow parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ diff = ["dissimilar"]
 dissimilar = { version = "1.0", optional = true }
 glob = "0.3"
 lazy_static = "1.3"
-rustc-hash = { version = "1.1.0", default-features = false }
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ diff = ["dissimilar"]
 dissimilar = { version = "1.0", optional = true }
 glob = "0.3"
 lazy_static = "1.3"
+rustc-hash = { version = "1.1.0", default-features = false }
 serde = { version = "1.0.103", features = ["derive"] }
 serde_json = "1.0"
 termcolor = "1.0.4"

--- a/src/run.rs
+++ b/src/run.rs
@@ -6,8 +6,8 @@ use crate::manifest::{Bin, Build, Config, Manifest, Name, Package, Workspace};
 use crate::message::{self, Fail, Warn};
 use crate::normalize::{self, Context, Variations};
 use crate::{features, rustflags, Expected, Runner, Test};
-use rustc_hash::FxHasher;
 use std::collections::BTreeMap as Map;
+use std::collections::hash_map::DefaultHasher;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
@@ -112,7 +112,7 @@ impl Runner {
 
         let mut project = Project {
             dir: path!(target_dir / "tests" / crate_name / {
-                let mut hasher = FxHasher::default();
+                let mut hasher = DefaultHasher::new();
                 self.tests.iter().map(|test| test.path.clone()).collect::<Vec<_>>().hash(&mut hasher);
                 hasher.finish()
             }.to_string()),


### PR DESCRIPTION
This PR resolves the issues that are run into when running two separate unit tests in the same crate (see issue #58). Previously, doing this would cause the test runners to use the same crate directory, leading to one overwriting the other's manifest. This resulted in confusing errors and tests failing to no fault of the user. 

To solve this, separate directories are defined for each run, using a hash of the test paths used by the `TestCase`. Therefore, the following now works correctly:

```rust
use trybuild::TestCases;

#[test]
fn test_1() {
    TestCases::new().compile_fail("compile_failures/1.rs");
}

#[test]
fn test_2() {
    TestCases::new().compile_fail("compile_failures/2.rs");
}
```

This does add a dependency on [`rustc-hash`](https://crates.io/crates/rustc-hash), the hasher used within `rustc`. I would say this is a trustworthy additional dependency, as it is owned by the Rust core team. The hash is not cryptographic, but it doesn't need to be for this use case. If you would rather not add this dependency, let me know and we can discuss another way.