### PR TITLE
Do not pass --target if user is not using --target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,34 @@ use std::path::Path;
 
 fn main() -> io::Result<()> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
-    let target = env::var("TARGET").ok();
+    let mut target = env::var("TARGET").ok();
+
+    // When --target flag is passed, cargo does not pass RUSTFLAGS to rustc when
+    // building proc-macro and build script even if the host and target triples
+    // are the same. Therefore, if we always pass --target to cargo, tools such
+    // as coverage that require RUSTFLAGS do not work for tests run by trybuild.
+    //
+    // To avoid that problem, do not pass --target to cargo if we know that it
+    // has not been passed.
+    //
+    // Cargo does not have a way to tell the build script whether --target has
+    // been passed or not, so we use the following heuristic:
+    //
+    // - The host and target triples are the same.
+    // - And RUSTFLAGS is available when *building* the build script.
+    //
+    // Note that the second is when building, not when running. This is due to:
+    //
+    // - After rust-lang/cargo#9601, cargo does not pass RUSTFLAGS to the build
+    //   script when running.
+    // - CARGO_ENCODED_RUSTFLAGS, which was introduced in rust-lang/cargo#9601,
+    //   cannot be used for this purpose because it contains the value of
+    //   RUSTFLAGS even if --target is passed and the host and target triples
+    //   are the same.
+    if target == env::var("HOST").ok() && option_env!("RUSTFLAGS").is_some() {
+        target = None;
+    }
+
     let path = Path::new(&out_dir).join("target.rs");
     let value = match target {
         Some(target) => format!("Some({:?})", target),


### PR DESCRIPTION
When `--target` flag is passed, cargo does not pass `RUSTFLAGS` to rustc when building proc-macro and build script even if the host and target triples are the same. Therefore, if we always pass `--target` to cargo, tools such as coverage that require `RUSTFLAGS` do not work for tests run by trybuild.

To avoid that problem, this patch change to not pass `--target` to cargo if we know that it has not been passed.

Cargo does not have a way to tell the build script whether `--target` has been passed or not, so we use the following heuristic:

- The host and target triples are the same.
- And `RUSTFLAGS` is available when *building* the build script.

Note that the second is when building, not when running. This is due to:

- After rust-lang/cargo#9601, cargo does not pass `RUSTFLAGS` to the build script when running. (see also https://github.com/alexcrichton/proc-macro2/issues/293)
- `CARGO_ENCODED_RUSTFLAGS`, which was introduced in rust-lang/cargo#9601, cannot be used for this purpose because it contains the value of `RUSTFLAGS` even if --target is passed and the host and target triples are the same.

Fixes #115

--- 

Tested with a case where using [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) and a case where using llvm-cov directly without any third party tools. See https://github.com/taiki-e/cargo-llvm-cov/pull/44#issuecomment-894656727 for one of the cases I actually tested.

I have not tested the other tools, but it is likely that they will need some change like https://github.com/taiki-e/cargo-llvm-cov/pull/44 on their side.

I also tested a case of #90, with a way discripted in #90.

> Tested with `cargo test --target x86_64-unknown-linux-gnu` inside a crate that has `[build] target = "thumbv7m-none-eabi"` in .cargo/config.

