### PR TITLE
Add cfg to always treat target as host

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,34 +5,7 @@ use std::path::Path;
 
 fn main() -> io::Result<()> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
-    let mut target = env::var("TARGET").ok();
-
-    // When --target flag is passed, cargo does not pass RUSTFLAGS to rustc when
-    // building proc-macro and build script even if the host and target triples
-    // are the same. Therefore, if we always pass --target to cargo, tools such
-    // as coverage that require RUSTFLAGS do not work for tests run by trybuild.
-    //
-    // To avoid that problem, do not pass --target to cargo if we know that it
-    // has not been passed.
-    //
-    // Cargo does not have a way to tell the build script whether --target has
-    // been passed or not, so we use the following heuristic:
-    //
-    // - The host and target triples are the same.
-    // - And RUSTFLAGS is available when *building* the build script.
-    //
-    // Note that the second is when building, not when running. This is due to:
-    //
-    // - After rust-lang/cargo#9601, cargo does not pass RUSTFLAGS to the build
-    //   script when running.
-    // - CARGO_ENCODED_RUSTFLAGS, which was introduced in rust-lang/cargo#9601,
-    //   cannot be used for this purpose because it contains the value of
-    //   RUSTFLAGS even if --target is passed and the host and target triples
-    //   are the same.
-    if target == env::var("HOST").ok() && option_env!("RUSTFLAGS").is_some() {
-        target = None;
-    }
-
+    let target = env::var("TARGET").ok();
     let path = Path::new(&out_dir).join("target.rs");
     let value = match target {
         Some(target) => format!(r#"Some("{}")"#, target.escape_debug()),

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,6 @@ fn main() -> io::Result<()> {
         Some(target) => format!(r#"Some("{}")"#, target.escape_debug()),
         None => "None".to_owned(),
     };
-    let content = format!("const TARGET: Option<&'static str> = {};", value);
+    let content = format!("const TARGET: Option<&str> = {};", value);
     fs::write(path, content)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,6 +245,22 @@ mod normalize;
 mod run;
 mod rustflags;
 
+// When --target flag is passed, cargo does not pass RUSTFLAGS to rustc when
+// building proc-macro and build script even if the host and target triples are
+// the same. Therefore, if we always pass --target to cargo, tools such as
+// coverage that require RUSTFLAGS do not work for tests run by trybuild.
+//
+// To avoid that problem, do not pass --target to cargo if we know that it has
+// not been passed.
+//
+// Currently, cargo does not have a way to tell the build script whether
+// --target has been passed or not, and there is no heuristic that can handle
+// this well.
+//
+// Therefore, expose a cfg to always treat the target as host.
+#[cfg(trybuild_no_target)]
+const TARGET: Option<&str> = None;
+#[cfg(not(trybuild_no_target))]
 include!(concat!(env!("OUT_DIR"), "/target.rs"));
 
 use std::cell::RefCell;


### PR DESCRIPTION
Unfortunately, currently, it seems there is no heuristic that can handle this well...

So at the moment, only approaches that "require the user to explicitly specify" such as environment variables and cfg seem to work.

This PR uses an approach that exposes a cfg to always treat the target as host.

In the future, once https://github.com/rust-lang/cargo/pull/9532 merged, we can support auto-detection of this.

Closes #122 