### PR TITLE
Improve assertion failure messages in test suite

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,7 +16,11 @@ macro_rules! test_normalize {
             };
             let original = $original.to_owned().into_bytes();
             let variations = super::diagnostics(original, context);
-            assert_eq!(variations.preferred(), $expected);
+            let preferred = variations.preferred();
+            let expected = $expected;
+            if preferred != expected {
+                panic!("\nACTUAL: \"{}\"\nEXPECTED: \"{}\"", preferred, expected);
+            }
         }
     };
 }


### PR DESCRIPTION
Before:

```console
thread 'normalize::tests::test_basic' panicked at 'assertion failed: `(left == right)`
  left: `"\nerror: `self` parameter is only allowed in associated functions\n  --> $DIR/error.rs:11:23\n   |\n11 | async fn bad_endpoint(self) -> Result<HttpResponseOkObject<()>, HttpError> {\n   |                       ^^^^ not semantically valid as function parameter\n"`,
 right: `"\nerror: self parameter is only allowed in associated functions\n  --> $DIR/error.rs:11:23\n   |\n11 | async fn bad_endpoint(self) -> Result<HttpResponseOkObject<()>, HttpError> {\n   |                       ^^^^ not semantically valid as function parameter\n"`', src/tests.rs:24:1
```

After:

```console
thread 'normalize::tests::test_basic' panicked at '
ACTUAL: "
error: `self` parameter is only allowed in associated functions
  --> $DIR/error.rs:11:23
   |
11 | async fn bad_endpoint(self) -> Result<HttpResponseOkObject<()>, HttpError> {
   |                       ^^^^ not semantically valid as function parameter
"
EXPECTED: "
error: self parameter is only allowed in associated functions
  --> $DIR/error.rs:11:23
   |
11 | async fn bad_endpoint(self) -> Result<HttpResponseOkObject<()>, HttpError> {
   |                       ^^^^ not semantically valid as function parameter
"', src/tests.rs:28:1
```