### PR TITLE
Wrap directory paths in a Directory type

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,16 +1,16 @@
+use crate::directory::Directory;
 use crate::error::{Error, Result};
 use crate::manifest::Name;
 use crate::run::Project;
 use crate::rustflags;
 use serde::Deserialize;
-use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
 
 #[derive(Deserialize)]
 pub struct Metadata {
-    pub target_directory: PathBuf,
-    pub workspace_root: PathBuf,
+    pub target_directory: Directory,
+    pub workspace_root: Directory,
     pub packages: Vec<Package>,
 }
 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::borrow::Cow;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(transparent)]
+pub struct Directory {
+    path: PathBuf,
+}
+
+impl Directory {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
+        let path = path.into();
+        //TODO: path.push("");
+        Directory { path }
+    }
+
+    pub fn to_string_lossy(&self) -> Cow<str> {
+        self.path.to_string_lossy()
+    }
+
+    pub fn join<P: AsRef<Path>>(&self, tail: P) -> PathBuf {
+        self.path.join(tail)
+    }
+
+    pub fn canonicalize(&self) -> io::Result<Self> {
+        self.path.canonicalize().map(Directory::new)
+    }
+}
+
+impl From<OsString> for Directory {
+    fn from(os_string: OsString) -> Self {
+        Directory::new(PathBuf::from(os_string))
+    }
+}
+
+impl AsRef<Path> for Directory {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl<'de> Deserialize<'de> for Directory {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        PathBuf::deserialize(deserializer).map(Directory::new)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,6 +236,7 @@ mod path;
 mod cargo;
 mod dependencies;
 mod diff;
+mod directory;
 mod env;
 mod error;
 mod features;

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -2,14 +2,14 @@
 #[path = "tests.rs"]
 mod tests;
 
+use crate::directory::Directory;
 use crate::run::PathDependency;
-use std::path::Path;
 
 #[derive(Copy, Clone)]
 pub struct Context<'a> {
     pub krate: &'a str,
-    pub source_dir: &'a Path,
-    pub workspace: &'a Path,
+    pub source_dir: &'a Directory,
+    pub workspace: &'a Directory,
     pub path_dependencies: &'a [PathDependency],
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -6,6 +6,10 @@ macro_rules! path {
 
 // Private implementation detail.
 macro_rules! tokenize_path {
+    ([$(($($component:tt)+))*] [$($cur:tt)+] /) => {
+        crate::directory::Directory::new(tokenize_path!([$(($($component)+))*] [$($cur)+]))
+    };
+
     ([$(($($component:tt)+))*] [$($cur:tt)+] / $($rest:tt)+) => {
         tokenize_path!([$(($($component)+))* ($($cur)+)] [] $($rest)+)
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
+use crate::directory::Directory;
 use crate::run::PathDependency;
-use std::path::Path;
 
 macro_rules! test_normalize {
     ($name:ident $original:literal $expected:literal) => {
@@ -7,11 +7,11 @@ macro_rules! test_normalize {
         fn $name() {
             let context = super::Context {
                 krate: "trybuild000",
-                source_dir: Path::new("/git/trybuild/test_suite"),
-                workspace: Path::new("/git/trybuild"),
+                source_dir: &Directory::new("/git/trybuild/test_suite"),
+                workspace: &Directory::new("/git/trybuild"),
                 path_dependencies: &[PathDependency {
                     name: String::from("diesel"),
-                    normalized_path: Path::new("/home/user/documents/rust/diesel/diesel").into(),
+                    normalized_path: Directory::new("/home/user/documents/rust/diesel/diesel"),
                 }],
             };
             let original = $original.to_owned().into_bytes();


### PR DESCRIPTION
Currently this is just a simple wrapper, but I'll be using it in an upcoming PR to guarantee that paths which are known to represent directories are always stored with a trailing `/`.

This invariant will be necessary during normalization so that for example with workspace=`/path/to` and source_dir=`/path/to/thing`, we do not substitute `/path/to/thing_macros/file.rs` to `$DIR_macros/file.rs` but instead correctly to `$WORKSPACE/thing_macros/file.rs`.