### PR TITLE
Prevent partial matching of source dir

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -12,8 +12,8 @@ pub struct Directory {
 
 impl Directory {
     pub fn new<P: Into<PathBuf>>(path: P) -> Self {
-        let path = path.into();
-        //TODO: path.push("");
+        let mut path = path.into();
+        path.push("");
         Directory { path }
     }
 

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -162,7 +162,7 @@ impl<'a> Filter<'a> {
                 .to_ascii_lowercase()
                 .replace('\\', "/");
             if let Some(i) = line_lower.find(&source_dir_pat) {
-                line.replace_range(i..i + source_dir_pat.len(), "$DIR");
+                line.replace_range(i..i + source_dir_pat.len() - 1, "$DIR");
                 return Some(line);
             }
             let mut other_crate = false;
@@ -173,7 +173,7 @@ impl<'a> Filter<'a> {
                 .to_ascii_lowercase()
                 .replace('\\', "/");
             if let Some(i) = line_lower.find(&workspace_pat) {
-                line.replace_range(i..i + workspace_pat.len(), "$WORKSPACE");
+                line.replace_range(i..i + workspace_pat.len() - 1, "$WORKSPACE");
                 other_crate = true;
             }
             if self.normalization >= PathDependencies && !other_crate {
@@ -185,7 +185,7 @@ impl<'a> Filter<'a> {
                         .replace('\\', "/");
                     if let Some(i) = line_lower.find(&path_dep_pat) {
                         let var = format!("${}", path_dep.name.to_uppercase().replace('-', "_"));
-                        line.replace_range(i..i + path_dep_pat.len(), &var);
+                        line.replace_range(i..i + path_dep_pat.len() - 1, &var);
                         other_crate = true;
                         break;
                     }
@@ -275,11 +275,11 @@ impl<'a> Filter<'a> {
         }
 
         line = line.replace(self.context.krate, "$CRATE");
-        line = replace_case_insensitive(&line, &self.context.source_dir.to_string_lossy(), "$DIR");
+        line = replace_case_insensitive(&line, &self.context.source_dir.to_string_lossy(), "$DIR/");
         line = replace_case_insensitive(
             &line,
             &self.context.workspace.to_string_lossy(),
-            "$WORKSPACE",
+            "$WORKSPACE/",
         );
 
         Some(line)


### PR DESCRIPTION
Follow-up to #129. For example in the case of workspace=`/path/to` and source_dir=`/path/to/thing`, we need to not substitute `/path/to/thing_macros/file.rs` to `$DIR_macros/file.rs` but instead correctly to `$WORKSPACE/thing_macros/file.rs`.