### PR TITLE
Always display path of test files

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -51,14 +51,7 @@ pub(crate) fn ok() {
 }
 
 pub(crate) fn begin_test(test: &Test, show_expected: bool) {
-    let display_name = if show_expected {
-        test.path
-            .file_name()
-            .unwrap_or_else(|| test.path.as_os_str())
-            .to_string_lossy()
-    } else {
-        test.path.as_os_str().to_string_lossy()
-    };
+    let display_name = test.path.as_os_str().to_string_lossy();
 
     print!("test ");
     term::bold();


### PR DESCRIPTION
Currently, the way file names are displayed is different when both pass and compile-fail are present, and when only one is present. This patch unifies the way file names are displayed.

This makes the message displayed a bit redundant, but I think it is preferable to the current one for the following reasons:

- Easy-to-read messages in cases where users want to group tests, like #94.
- Consistency with the path display format in stderr files, introduced in https://github.com/dtolnay/trybuild/commit/508b39f622491569c3260d497aa036f3ebe453bb. ($DIR/file.rs -> path/file.rs)


Closes #94 