### PR TITLE
Copy all features from the features key in the Cargo.toml.

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -178,10 +178,14 @@ impl Runner {
 
         let features = source_manifest
             .features
-            .keys()
-            .map(|feature| {
-                let enable = format!("{}/{}", crate_name, feature);
-                (feature.clone(), vec![enable])
+            .iter()
+            .map(|(feature_key, additional) | {
+                let enable_self = format!("{}/{}", crate_name, feature_key);
+
+                let mut enable_additional = vec![enable_self];
+                enable_additional.extend_from_slice(&additional);
+
+                (feature_key.clone(), enable_additional)
             })
             .collect();
 


### PR DESCRIPTION
Hey

This is my understanding of what is needed to fix issue #145 

I've changed the way features are read from the source manifest. 
Instead of only copying the single feature enable e.g. `crate_name/feature_name`, the code now adds all values from the given feature key in the source manifest in addition to `crate_name/feature_name`.

To take the linked issue as an example, the current version creates a `Cargo.toml` features section:

```toml
[features]
foo = ["dependency_a/foo"]
```

With this addition the test compiles as expected. The `Cargo.toml` features  section now reads:

```toml
[features]
foo = ["dependency_a/foo", "dependency_b/foo"]
```