### PR TITLE
Obtain rendered diagnostics through `--message-format=json`

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -80,6 +80,7 @@ pub fn build_test(project: &Project, name: &Name) -> Result<Output> {
         .args(features(project))
         .arg("--quiet")
         .arg("--color=never")
+        .arg("--message-format=json")
         .output()
         .map_err(Error::Cargo)
 }


### PR DESCRIPTION
This PR switches to getting rustc's diagnostics message through Cargo's "JSON messages" functionality, which is described in https://doc.rust-lang.org/1.59.0/cargo/reference/external-tools.html#json-messages.

This doesn't immediately offer an improvement, but this is a necessary step to leveraging Cargo's new `--keep-going` flag to build all the ui test inputs simultaneously instead of one after the other, which will be an enormous speed improvement. Without JSON messages, tests which are compiled simultaneously would end up interleaving diagnostics in a way that makes it impossible to separate and attribute each diagnostic to which input file's build it relates to.

See https://github.com/rust-lang/cargo/pull/10383 &amp; https://github.com/rust-lang/cargo/issues/10496 for more on `--keep-going`.

I confirmed that `cxx` and `serde`, both of which have large ui test suites, both pass with this change.

- https://github.com/dtolnay/cxx/tree/1.0.66/tests/ui
- https://github.com/serde-rs/serde/tree/v1.0.136/test_suite/tests/ui