### PR TITLE
Add logic to check for --keep-going support

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,18 @@
+use std::fs;
+use std::io::Result;
+use std::path::Path;
+
+pub fn write_if_needed<P, C>(path: P, contents: C) -> Result<()>
+where
+    P: AsRef<Path>,
+    C: AsRef<[u8]>,
+{
+    let path = path.as_ref();
+    let contents = contents.as_ref();
+    if let Ok(existing_contents) = fs::read(path) {
+        if existing_contents == contents {
+            return Ok(());
+        }
+    }
+    fs::write(path, contents)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,7 @@ mod env;
 mod error;
 mod features;
 mod flock;
+mod fs;
 mod manifest;
 mod message;
 mod normalize;

--- a/src/run.rs
+++ b/src/run.rs
@@ -31,6 +31,8 @@ pub struct Project {
     pub workspace: Directory,
     pub path_dependencies: Vec<PathDependency>,
     manifest: Manifest,
+    #[allow(dead_code)]
+    keep_going: bool,
 }
 
 #[derive(Debug)]
@@ -137,7 +139,7 @@ impl Runner {
             enabled_features.retain(|feature| manifest.features.contains_key(feature));
         }
 
-        Ok(Project {
+        let mut project = Project {
             dir: project_dir,
             source_dir,
             target_dir,
@@ -149,7 +151,12 @@ impl Runner {
             workspace,
             path_dependencies,
             manifest,
-        })
+            keep_going: false,
+        };
+
+        project.keep_going = cargo::supports_keep_going(&project).unwrap_or(false);
+
+        Ok(project)
     }
 
     fn write(&self, project: &Project) -> Result<()> {


### PR DESCRIPTION
This will allow conditionally using https://github.com/rust-lang/cargo/pull/10383 on toolchains that support it.