### PR TITLE
Explicitly allow unused crate dependencies and missing docs

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -163,7 +163,10 @@ impl Runner {
         fs::create_dir_all(path!(project.dir / ".cargo"))?;
         fs::write(path!(project.dir / ".cargo" / "config"), config_toml)?;
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
-        fs::write(path!(project.dir / "main.rs"), b"fn main() {}\n")?;
+        fs::write(
+            path!(project.dir / "main.rs"),
+            b"#![allow(unused_crate_dependencies, missing_docs)]\nfn main() {}\n",
+        )?;
 
         cargo::build_dependencies(project)?;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -163,10 +163,15 @@ impl Runner {
         fs::create_dir_all(path!(project.dir / ".cargo"))?;
         fs::write(path!(project.dir / ".cargo" / "config"), config_toml)?;
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
-        fs::write(
-            path!(project.dir / "main.rs"),
-            b"#![allow(unused_crate_dependencies, missing_docs)]\nfn main() {}\n".to_vec(),
-        )?;
+
+        let main_rs = b"#![allow(\
+                unknown_lints, \
+                unused_crate_dependencies, \
+                missing_docs\
+            )]\n\
+            fn main() {}\n\
+        ";
+        fs::write(path!(project.dir / "main.rs"), main_rs.to_vec())?;
 
         cargo::build_dependencies(project)?;
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -165,7 +165,7 @@ impl Runner {
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
         fs::write(
             path!(project.dir / "main.rs"),
-            b"#![allow(unused_crate_dependencies, missing_docs)]\nfn main() {}\n",
+            b"#![allow(unused_crate_dependencies, missing_docs)]\nfn main() {}\n".to_vec(),
         )?;
 
         cargo::build_dependencies(project)?;


### PR DESCRIPTION
Without this annotation, the main file generated by trybuild will always raise a warning/error on the respective setting for these compiler lints.

Explicitly allowing it here should have the net result of letting tests written using trybuild handle just like any other test in an environment with that lint set, and otherwise not make a difference.