### PR TITLE
Preserve enabled features when making new manifest.

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -216,10 +216,11 @@ impl Runner {
 
         let features = source_manifest
             .features
-            .keys()
-            .map(|feature| {
-                let enable = format!("{}/{}", crate_name, feature);
-                (feature.clone(), vec![enable])
+            .iter()
+            .map(|(feature, enabled_features)| {
+                let mut updated_enabled_features = enabled_features.clone();
+                updated_enabled_features.push(format!("{}/{}", crate_name, feature));
+                (feature.clone(), updated_enabled_features)
             })
             .collect();
 


### PR DESCRIPTION
This is a proposed solution to #171. This change preserves the feature graph from the source crate when making the manifest for the test crate. This shouldn't cause any adverse effects, as these same features will be enabled in the source crate anyways when a specific feature is enabled.

This fixes the minimal reproducible example I presented in #171.