### PR TITLE
Search for Cargo.toml if CARGO_MANIFEST_DIR not set

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -43,6 +43,19 @@ fn cargo_target_dir(project: &Project) -> impl Iterator<Item = (&'static str, Pa
     ))
 }
 
+pub fn manifest_dir() -> Result<Directory> {
+    if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
+        return Ok(Directory::from(manifest_dir));
+    }
+    let mut dir = Directory::current()?;
+    loop {
+        if dir.join("Cargo.toml").exists() {
+            return Ok(dir);
+        }
+        dir = dir.parent().ok_or(Error::ProjectDir)?;
+    }
+}
+
 pub fn build_dependencies(project: &mut Project) -> Result<()> {
     let workspace_cargo_lock = path!(project.workspace / "Cargo.lock");
     if workspace_cargo_lock.exists() {

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -1,6 +1,7 @@
 use serde::de::{Deserialize, Deserializer};
 use serde_derive::Serialize;
 use std::borrow::Cow;
+use std::env;
 use std::ffi::OsString;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -18,12 +19,20 @@ impl Directory {
         Directory { path }
     }
 
+    pub fn current() -> io::Result<Self> {
+        env::current_dir().map(Directory::new)
+    }
+
     pub fn to_string_lossy(&self) -> Cow<str> {
         self.path.to_string_lossy()
     }
 
     pub fn join<P: AsRef<Path>>(&self, tail: P) -> PathBuf {
         self.path.join(tail)
+    }
+
+    pub fn parent(&self) -> Option<Self> {
+        self.path.parent().map(Directory::new)
     }
 
     pub fn canonicalize(&self) -> io::Result<Self> {

--- a/src/run.rs
+++ b/src/run.rs
@@ -123,9 +123,7 @@ impl Runner {
             }
         }
 
-        let source_dir = env::var_os("CARGO_MANIFEST_DIR")
-            .map(Directory::from)
-            .ok_or(Error::ProjectDir)?;
+        let source_dir = cargo::manifest_dir()?;
         let source_manifest = dependencies::get_manifest(&source_dir);
 
         let mut features = features::find();


### PR DESCRIPTION
In addition to #176, this is also needed in order for directly running an integration test binary without cargo to work (#14).