### PR TITLE
Only do overriding of pass/fail status for tests expanded from glob

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -9,6 +9,7 @@ pub(crate) struct ExpandedTest {
     pub name: Name,
     pub test: Test,
     pub error: Option<Error>,
+    is_from_glob: bool,
 }
 
 pub(crate) fn expand_globs(tests: &[Test]) -> Vec<ExpandedTest> {
@@ -20,12 +21,12 @@ pub(crate) fn expand_globs(tests: &[Test]) -> Vec<ExpandedTest> {
                 Ok(paths) => {
                     let expected = test.expected;
                     for path in paths {
-                        set.insert(Test { path, expected }, None);
+                        set.insert(Test { path, expected }, None, true);
                     }
                 }
-                Err(error) => set.insert(test.clone(), Some(error)),
+                Err(error) => set.insert(test.clone(), Some(error), false),
             },
-            _ => set.insert(test.clone(), None),
+            _ => set.insert(test.clone(), None, false),
         }
     }
 
@@ -45,15 +46,24 @@ impl ExpandedTestSet {
         }
     }
 
-    fn insert(&mut self, test: Test, error: Option<Error>) {
+    fn insert(&mut self, test: Test, error: Option<Error>, is_from_glob: bool) {
         if let Some(&i) = self.path_to_index.get(&test.path) {
-            self.vec[i].test.expected = test.expected;
-        } else {
-            let index = self.vec.len();
-            let name = Name(format!("trybuild{:03}", index));
-            self.path_to_index.insert(test.path.clone(), index);
-            self.vec.push(ExpandedTest { name, test, error });
+            let mut prev = &mut self.vec[i];
+            if prev.is_from_glob {
+                prev.test.expected = test.expected;
+                return;
+            }
         }
+
+        let index = self.vec.len();
+        let name = Name(format!("trybuild{:03}", index));
+        self.path_to_index.insert(test.path.clone(), index);
+        self.vec.push(ExpandedTest {
+            name,
+            test,
+            error,
+            is_from_glob,
+        });
     }
 }
 


### PR DESCRIPTION
Something like `t.compile_fail("foo.rs"); t.pass("foo.rs");` is probably a copy&ndash;paste error, not intentional.