### PR TITLE
Report error from parsing Cargo.toml

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 pub enum Error {
     Cargo(io::Error),
     CargoFail,
+    GetManifest(PathBuf, Box<Error>),
     Glob(GlobError),
     Io(io::Error),
     Metadata(serde_json::Error),
@@ -33,6 +34,7 @@ impl Display for Error {
         match self {
             Cargo(e) => write!(f, "failed to execute cargo: {}", e),
             CargoFail => write!(f, "cargo reported an error"),
+            GetManifest(path, e) => write!(f, "failed to read manifest {}: {}", path.display(), e),
             Glob(e) => write!(f, "{}", e),
             Io(e) => write!(f, "{}", e),
             Metadata(e) => write!(f, "failed to read cargo metadata: {}", e),

--- a/src/run.rs
+++ b/src/run.rs
@@ -125,7 +125,7 @@ impl Runner {
         }
 
         let source_dir = cargo::manifest_dir()?;
-        let source_manifest = dependencies::get_manifest(&source_dir);
+        let source_manifest = dependencies::get_manifest(&source_dir)?;
 
         let mut features = features::find();
 


### PR DESCRIPTION
`unwrap_or_default()` is unhelpful here because it'll return a `Manifest` containing package.name="". As currently implemented, that screws up this line:

https://github.com/dtolnay/trybuild/blob/bce5f95b2ebedec3915dd71f8e426dbf8d72a4cd/src/run.rs#L153

because it ends up with `--crate-name -tests` getting passed to Cargo:

```console
running 1 test
error: Found argument '-t' which wasn't expected, or isn't valid in this context

	If you tried to supply `-t` as a value rather than a flag, use `-- -t`

USAGE:
    cargo check [OPTIONS]

For more information try --help
test compile_fail ... FAILED
```

Even if we fix that, the generated Cargo.toml needs to list the original library under `[dependencies]`, which it can't do unless we have a package name for it.