### PR TITLE
Normalize "and x others"

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -61,6 +61,7 @@ pub fn diagnostics(output: &str, context: Context) -> Variations {
         RelativeToDir,
         LinesOutsideInputFile,
         Unindent,
+        AndOther,
     ]
     .iter()
     .map(|normalization| apply(&output, *normalization, context))
@@ -100,6 +101,7 @@ enum Normalization {
     RelativeToDir,
     LinesOutsideInputFile,
     Unindent,
+    AndOther,
     // New normalization steps are to be inserted here at the end so that any
     // snapshots saved before your normalization change remain passing.
 }
@@ -349,6 +351,15 @@ impl<'a> Filter<'a> {
             &self.context.workspace.to_string_lossy(),
             "$WORKSPACE/",
         );
+
+        if self.normalization >= AndOther {
+            // Replace any "and 123 others" with "and $COUNT others"
+            if line.trim_start().starts_with("and") && line.trim_end().ends_with("others") {
+                let start = line.find("and").unwrap() + 4;
+                let end = line.find("others").unwrap() - 1;
+                line.replace_range(start..end, "$COUNT");
+            }
+        }
 
         Some(line)
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -19,4 +19,5 @@ fn test() {
     t.pass("tests/ui/run-pass-9.rs");
     t.compile_fail("tests/ui/compile-fail-2.rs");
     t.compile_fail("tests/ui/compile-fail-3.rs");
+    t.compile_fail("tests/ui/normalize_and_x_others.rs");
 }

--- a/tests/ui/normalize_and_x_others.rs
+++ b/tests/ui/normalize_and_x_others.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _x = 42_u8 >> "bar";
+}

--- a/tests/ui/normalize_and_x_others.stderr
+++ b/tests/ui/normalize_and_x_others.stderr
@@ -1,0 +1,17 @@
+error[E0277]: no implementation for `u8 >> &str`
+ --> tests/ui/normalize_and_x_others.rs:2:20
+  |
+2 |     let _x = 42_u8 >> "bar";
+  |                    ^^ no implementation for `u8 >> &str`
+  |
+  = help: the trait `Shr<&str>` is not implemented for `u8`
+  = help: the following other types implement trait `Shr<Rhs>`:
+            <&'a i128 as Shr<i128>>
+            <&'a i128 as Shr<i16>>
+            <&'a i128 as Shr<i32>>
+            <&'a i128 as Shr<i64>>
+            <&'a i128 as Shr<i8>>
+            <&'a i128 as Shr<isize>>
+            <&'a i128 as Shr<u128>>
+            <&'a i128 as Shr<u16>>
+          and $COUNT others


### PR DESCRIPTION
This solves a major pain point for me; I have many features that add trait implementations. As such the exact number varies and that makes matching this error message very painful.