### PR TITLE
Tell libfuzzer the desired input size range

### DIFF
--- a/fuzz/fuzz_targets/normalize.rs
+++ b/fuzz/fuzz_targets/normalize.rs
@@ -10,8 +10,11 @@ mod normalize;
 use crate::directory::Directory;
 use crate::normalize::Context;
 use crate::run::PathDependency;
+use libfuzzer_sys::arbitrary::{self, Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
+use std::fmt::{self, Debug};
 use std::path::Path;
+use std::str;
 
 mod run {
     pub struct PathDependency {
@@ -20,10 +23,32 @@ mod run {
     }
 }
 
-fuzz_target!(|string: &str| {
-    if string.len() > 500 {
-        return;
+struct Input<'a>(&'a str);
+
+impl<'a> Debug for Input<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(self.0, formatter)
     }
+}
+
+impl<'a> Arbitrary<'a> for Input<'a> {
+    fn arbitrary(_u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        unreachable!()
+    }
+
+    fn arbitrary_take_rest(u: Unstructured<'a>) -> arbitrary::Result<Self> {
+        match str::from_utf8(u.take_rest()) {
+            Ok(s) => Ok(Input(s)),
+            Err(_) => Err(arbitrary::Error::IncorrectFormat),
+        }
+    }
+
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (0, Some(500))
+    }
+}
+
+fuzz_target!(|input: Input| {
     let context = Context {
         krate: "trybuild000",
         input_file: Path::new("tests/ui/error.rs"),
@@ -35,5 +60,5 @@ fuzz_target!(|string: &str| {
             normalized_path: Directory::new("/home/user/documents/rust/diesel/diesel"),
         }],
     };
-    let _ = normalize::diagnostics(string, context);
+    let _ = normalize::diagnostics(input.0, context);
 });


### PR DESCRIPTION
As far as I can tell this does not make a difference :crying_cat_face:. The distribution of input sizes is identical before and after.