### PR TITLE
Turn off incremental compilation

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -39,6 +39,7 @@ fn cargo(project: &Project) -> Command {
     cmd.current_dir(&project.dir);
     cmd.envs(cargo_target_dir(project));
     cmd.envs(rustflags::envs());
+    cmd.env("CARGO_INCREMENTAL", "0");
     cmd.arg("--offline");
     cmd
 }


### PR DESCRIPTION
This works around https://github.com/rust-lang/rust/issues/106571. However this might be the right choice anyway for trybuild. I'll think about whether to remove it once the rustc bug is gone.