### PR TITLE
Use subdirectory within target/tests/

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -47,7 +47,7 @@ fn cargo(project: &Project) -> Command {
 fn cargo_target_dir(project: &Project) -> impl Iterator<Item = (&'static str, PathBuf)> {
     iter::once((
         "CARGO_TARGET_DIR",
-        path!(project.target_dir / "tests" / "target"),
+        path!(project.target_dir / "tests" / "trybuild"),
     ))
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -147,7 +147,7 @@ impl Runner {
             .collect();
 
         let crate_name = &source_manifest.package.name;
-        let project_dir = path!(target_dir / "tests" / crate_name /);
+        let project_dir = path!(target_dir / "tests" / "trybuild" / crate_name /);
         fs::create_dir_all(&project_dir)?;
 
         let project_name = format!("{}-tests", crate_name);


### PR DESCRIPTION
Or to put it another way, do not assume that the project's `target/tests/target/` is ours to use as we wish.

Empirically, this is sufficient on its own to resolve
  https://github.com/eupn/macrotest/issues/83
  https://github.com/dtolnay/trybuild/issues/218

(I don't know precisely what the difference is between trybuild's and mcarotest's build invocations.  It is possible that it would be better for cargo to be able to cache both in the target directory, but I think we should use a namespaced directory, regardless.)

I will be submitting a similar merge request for macrotest, which, likewise, is sufficient on its own to resolve the problem I was experiencing.  I think these changes should be made to both packages.