### PR TITLE
Fix normalization of rust lib path for some cases

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -282,6 +282,18 @@ impl<'a> Filter<'a> {
                     // ::: $RUST/std/src/net/ip.rs:83:1
                     line.replace_range(line.find(prefix).unwrap() + 4..pos + 25, "$RUST");
                     other_crate = true;
+                } else if let (Some(pos_rustc), Some(pos_library)) =
+                    (line.find("/rustc/"), line.find("/library/"))
+                {
+                    // source: /rustc/c5c7d2b37780dac1092e75f12ab97dd56c30861d/library/core/src/fmt/mod.rs:786:1
+                    // ::: $RUST/core/src/fmt/mod.rs
+                    if pos_library == pos_rustc + 47 {
+                        line.replace_range(
+                            line.find(prefix).unwrap() + 4..pos_library + 8,
+                            "$RUST",
+                        );
+                        other_crate = true;
+                    }
                 }
             }
             if self.normalization >= CargoRegistry && !other_crate {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -264,6 +264,47 @@ note: the following traits must be implemented
   = note: this error originates in the macro `anyhow` (in Nightly builds, run with -Z macro-backtrace for more info)
 "}
 
+test_normalize! {rust_lib_with_githash
+"
+error[E0599]: the method `to_cxx_exception` exists for reference `&NonError`, but its trait bounds were not satisfied
+ --> tests/ui/result_no_display.rs:4:19
+  |
+4 |         fn f() -> Result<()>;
+  |                   ^^^^^^^^^^ method cannot be called on `&NonError` due to unsatisfied trait bounds
+...
+8 | pub struct NonError;
+  | ------------------- doesn't satisfy `NonError: std::fmt::Display`
+  |
+  = note: the following trait bounds were not satisfied:
+          `NonError: std::fmt::Display`
+          which is required by `&NonError: ToCxxExceptionDefault`
+note: the trait `std::fmt::Display` must be implemented
+ --> /rustc/c5c7d2b37780dac1092e75f12ab97dd56c30861d/library/core/src/fmt/mod.rs:786:1
+  |
+  | pub trait Display {
+  | ^^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `::cxx::map_rust_error_to_cxx_exception` (in Nightly builds, run with -Z macro-backtrace for more info)
+" "
+error[E0599]: the method `to_cxx_exception` exists for reference `&NonError`, but its trait bounds were not satisfied
+ --> tests/ui/result_no_display.rs:4:19
+  |
+4 |         fn f() -> Result<()>;
+  |                   ^^^^^^^^^^ method cannot be called on `&NonError` due to unsatisfied trait bounds
+...
+8 | pub struct NonError;
+  | ------------------- doesn't satisfy `NonError: std::fmt::Display`
+  |
+  = note: the following trait bounds were not satisfied:
+          `NonError: std::fmt::Display`
+          which is required by `&NonError: ToCxxExceptionDefault`
+note: the trait `std::fmt::Display` must be implemented
+ --> $RUST/core/src/fmt/mod.rs
+  |
+  | pub trait Display {
+  | ^^^^^^^^^^^^^^^^^
+  = note: this error originates in the macro `::cxx::map_rust_error_to_cxx_exception` (in Nightly builds, run with -Z macro-backtrace for more info)
+"}
+
 test_normalize! {test_pyo3_url
     DIR="/pyo3"
     WORKSPACE="/pyo3"


### PR DESCRIPTION
Fixed normalization of paths in form:
`/rustc/c5c7d2b37780dac1092e75f12ab97dd56c30861d/library/core/src/fmt/mod.rs:786:1`