### PR TITLE
Rename .cargo/config to the preferred form .cargo/config.toml

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -43,6 +43,6 @@ fn test_path_macro() {
         dir: PathBuf::from("../target/tests"),
     };
 
-    let cargo_dir = path!(project.dir / ".cargo" / "config");
-    assert_eq!(cargo_dir, Path::new("../target/tests/.cargo/config"));
+    let cargo_dir = path!(project.dir / ".cargo" / "config.toml");
+    assert_eq!(cargo_dir, Path::new("../target/tests/.cargo/config.toml"));
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -187,7 +187,7 @@ impl Runner {
         let config_toml = basic_toml::to_string(&config)?;
 
         fs::create_dir_all(path!(project.dir / ".cargo"))?;
-        fs::write(path!(project.dir / ".cargo" / "config"), config_toml)?;
+        fs::write(path!(project.dir / ".cargo" / "config.toml"), config_toml)?;
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
 
         let main_rs = b"\


### PR DESCRIPTION
According to https://doc.rust-lang.org/1.67.0/cargo/reference/config.html#hierarchical-structure config.toml is the preferred form, and is supported since Rust 1.39 whereas trybuild's current oldest supported compiler is 1.45.