### PR TITLE
Add `$CARGO` normalization for new sparse protocol `/registry/src/index.crates.io-`

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -294,8 +294,11 @@ impl<'a> Filter<'a> {
                 }
             }
             if self.normalization >= CargoRegistry && !other_crate {
-                if let Some(pos) = line.find("/registry/src/github.com-") {
-                    let hash_start = pos + 25;
+                if let Some(pos) = line
+                    .find("/registry/src/github.com-")
+                    .or_else(|| line.find("/registry/src/index.crates.io-"))
+                {
+                    let hash_start = pos + line[pos..].find('-').unwrap() + 1;
                     let hash_end = hash_start + 16;
                     if line
                         .get(hash_start..hash_end)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -218,6 +218,42 @@ error[E0277]: the trait bound `Thread: serde::de::Deserialize<'_>` is not satisf
   |        ------------------- required by this bound in `serde_json::from_str`
 "}
 
+test_normalize! {test_cargo_registry_sparse "
+error[E0308]: mismatched types
+Error:   --> tests/compile-fail/surface_source_interval_badarg.rs:7:25
+   |
+5  |       let mut df = hydroflow_syntax! {
+   |  __________________-
+6  | |         // Should be a `Duration`.
+7  | |         source_interval(5) -> for_each(std::mem::drop);
+   | |                         ^ expected `Duration`, found integer
+8  | |     };
+   | |_____- arguments to this function are incorrect
+   |
+note: function defined here
+  --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.26.0/src/time/interval.rs:74:8
+   |
+74 | pub fn interval(period: Duration) -> Interval {
+   |        ^^^^^^^^
+" "
+error[E0308]: mismatched types
+Error:   --> tests/compile-fail/surface_source_interval_badarg.rs:7:25
+   |
+5  |       let mut df = hydroflow_syntax! {
+   |  __________________-
+6  | |         // Should be a `Duration`.
+7  | |         source_interval(5) -> for_each(std::mem::drop);
+   | |                         ^ expected `Duration`, found integer
+8  | |     };
+   | |_____- arguments to this function are incorrect
+   |
+note: function defined here
+  --> $CARGO/tokio-1.26.0/src/time/interval.rs
+   |
+   | pub fn interval(period: Duration) -> Interval {
+   |        ^^^^^^^^
+"}
+
 test_normalize! {test_traits_must_be_implemented "
 error[E0599]: the method `anyhow_kind` exists for reference `&Error`, but its trait bounds were not satisfied
    --> src/main.rs:7:13


### PR DESCRIPTION
Cargo's sparse protocol: https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
Has `index.crates.io-` rather than `github.com-`.