### PR TITLE
No more need for unknown_lints suppression

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -191,7 +191,7 @@ impl Runner {
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
 
         let main_rs = b"\
-            #![allow(unknown_lints, unused_crate_dependencies, missing_docs)]\n\
+            #![allow(unused_crate_dependencies, missing_docs)]\n\
             fn main() {}\n\
         ";
         fs::write(path!(project.dir / "main.rs"), &main_rs[..])?;


### PR DESCRIPTION
`warn(unused_crate_dependencies)` was introduced in Rust 1.45 by https://github.com/rust-lang/rust/pull/72342. At the time, trybuild supported rustc 1.36+. These days it requires rustc 1.56+.