### PR TITLE
strip rust src lines during normalization

### DIFF
--- a/src/tests/rust-lib-with-githash.rs
+++ b/src/tests/rust-lib-with-githash.rs
@@ -32,8 +32,5 @@ error[E0599]: the method `to_cxx_exception` exists for reference `&NonError`, bu
           which is required by `&NonError: ToCxxExceptionDefault`
 note: the trait `std::fmt::Display` must be implemented
  --> $RUST/core/src/fmt/mod.rs
-  |
-  | pub trait Display {
-  | ^^^^^^^^^^^^^^^^^
   = note: this error originates in the macro `::cxx::map_rust_error_to_cxx_exception` (in Nightly builds, run with -Z macro-backtrace for more info)
 "}

--- a/src/tests/rust-lib.rs
+++ b/src/tests/rust-lib.rs
@@ -23,9 +23,4 @@ error[E0599]: no method named `quote_into_iter` found for struct `std::net::Ipv4
   |
  ::: $RUST/src/libstd/net/ip.rs
  ::: $RUST/std/src/net/ip.rs
-  |
-  | pub struct Ipv4Addr {
-  | -------------------
-  | |
-  | doesn't satisfy `std::net::Ipv4Addr: quote::to_tokens::ToTokens`
 "}

--- a/src/tests/traits-must-be-implemented.rs
+++ b/src/tests/traits-must-be-implemented.rs
@@ -63,23 +63,6 @@ error[E0599]: the method `anyhow_kind` exists for reference `&Error`, but its tr
           which is required by `&Error: anyhow::private::kind::TraitKind`
 note: the following traits must be implemented
  --> $RUST/core/src/convert/mod.rs
-  |
-  | / pub trait Into<T>: Sized {
-  | |     /// Performs the conversion.
-  | |     #[stable(feature = \"rust1\", since = \"1.0.0\")]
-  | |     fn into(self) -> T;
-  | | }
-  | |_^
-  |
  ::: $RUST/core/src/fmt/mod.rs
-  |
-  | / pub trait Display {
-  | |     /// Formats the value using the given formatter.
-  | |     ///
-  | |     /// # Examples
-... |
-  | |     fn fmt(&self, f: &mut Formatter<'_>) -> Result;
-  | | }
-  | |_^
   = note: this error originates in the macro `anyhow` (in Nightly builds, run with -Z macro-backtrace for more info)
 "}

--- a/tests/ui/compile-fail-3.stderr
+++ b/tests/ui/compile-fail-3.stderr
@@ -1,9 +1,20 @@
 error[E0277]: `*mut _` cannot be shared between threads safely
-   --> tests/ui/compile-fail-3.rs:7:5
-    |
-7   |     thread::spawn(|| {
-    |     ^^^^^^^^^^^^^ `*mut _` cannot be shared between threads safely
-    |
-    = help: the trait `Sync` is not implemented for `*mut _`
-    = note: required because of the requirements on the impl of `Send` for `&*mut _`
-    = note: required because it appears within the type `[closure@$DIR/tests/ui/compile-fail-3.rs:7:19: 9:6]`
+ --> tests/ui/compile-fail-3.rs:7:19
+  |
+7 |       thread::spawn(|| {
+  |  _____-------------_^
+  | |     |
+  | |     required by a bound introduced by this call
+8 | |         println!("{:?}", x)
+9 | |     });
+  | |_____^ `*mut _` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `*mut _`
+  = note: required for `&*mut _` to implement `Send`
+note: required because it's used within this closure
+ --> tests/ui/compile-fail-3.rs:7:19
+  |
+7 |     thread::spawn(|| {
+  |                   ^^
+note: required by a bound in `spawn`
+ --> $RUST/std/src/thread/mod.rs


### PR DESCRIPTION
This adds a new normalization to `trybuild` to remove src lines which originate from `rust-src`. The `rustup` default profile does not contain the `rust-src` component, so I argue this normalization is justified as it makes the `trybuild` outputs consistent with what a user with a default rust install would see.

This is a follow-up to #126, which was resolved with a working alternative at the time.

---

For some context: As of this week, the PyO3 CI has ground to a halt, there is a bad interaction between `rustup` and GitHub Actions runner images which is causing `rust-src` component to fail to install, see https://github.com/rust-lang/rustup/issues/3530

While there are several solutions we can employ to workaround the issue, this option seems like a potential plus for the ecosystem while also removing our need to install `rust-src`.