### PR TITLE
Work around dead_code warning in flock implementation

### DIFF
--- a/src/flock.rs
+++ b/src/flock.rs
@@ -19,7 +19,7 @@ pub struct Lock {
 // integration test crate.
 enum Guard {
     NotLocked,
-    Locked(MutexGuard<'static, ()>),
+    Locked(#[allow(dead_code)] MutexGuard<'static, ()>),
 }
 
 // Best-effort filesystem lock to coordinate different #[test] functions across


### PR DESCRIPTION
Warning is new in nightly-2024-01-06 due to https://github.com/rust-lang/rust/pull/118297.

```console
warning: field `0` is never read
  --> src/flock.rs:22:12
   |
22 |     Locked(MutexGuard<'static, ()>),
   |     ------ ^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     field in this variant
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
22 |     Locked(()),
   |            ~~
```