### PR TITLE
Normalize compiler build date note

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -336,6 +336,12 @@ impl<'a> Filter<'a> {
             return None;
         }
 
+        if trim_start.starts_with("= note: this compiler was built on 2")
+            && trim_start.ends_with("; consider upgrading it if it is out of date")
+        {
+            return None;
+        }
+
         if self.normalization >= StripCouldNotCompile {
             if line.starts_with("error: Could not compile `") {
                 return None;

--- a/src/tests/gated-feature.rs
+++ b/src/tests/gated-feature.rs
@@ -1,0 +1,20 @@
+test_normalize! {"
+error[E0658]: `#[used(linker)]` is currently unstable
+ --> tests/ui/used-linker.rs:6:5
+  |
+6 |     #![used(linker)]
+  |     ^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
+  = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
+  = note: this compiler was built on 2024-01-13; consider upgrading it if it is out of date
+" "
+error[E0658]: `#[used(linker)]` is currently unstable
+ --> tests/ui/used-linker.rs:6:5
+  |
+6 |     #![used(linker)]
+  |     ^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
+  = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
+"}


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/119088, rustc is putting the compiler build date into diagnostics, which is inappropriate for ui tests.

```console
error[E0658]: `#[used(linker)]` is currently unstable
 --> tests/ui/used-linker.rs:6:5
  |
6 |     #![used(linker)]
  |     ^^^^^^^^^^^^^^^^
  |
  = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
  = help: add `#![feature(used_with_arg)]` to the crate attributes to enable
  = note: this compiler was built on 2024-01-13; consider upgrading it if it is out of date
```