### PR TITLE
Force rebuild on new files in tests directory

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::path::Path;
 
 fn main() -> io::Result<()> {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/tests");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let target = env::var("TARGET").ok();


### PR DESCRIPTION
Otherwise, if `cargo test --lib` has previously succeeded, and a new test is dropped into src/tests without touching any pre-existing source file in the crate, then another `cargo test --lib` will not perform a rebuild and the new test is not picked up by automod.

https://github.com/dtolnay/trybuild/blob/840b110e7593310995d398db995041ba500cb5d7/src/tests.rs#L34-L36