### PR TITLE
Update MSRV to reflect changes to dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["screenshots/*"]
 keywords = ["macros", "testing", "dev-dependencies"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/trybuild"
-rust-version = "1.56"
+rust-version = "1.70"
 
 [features]
 # Experimental: highlight the diff between the expected and actual compiler

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ misuse of non-macro APIs.
 trybuild = "1.0"
 ```
 
-*Compiler support: requires rustc 1.45+*
-
 <br>
 
 ## Compile-fail tests


### PR DESCRIPTION
Replacing basic-toml crate in dtolnay/trybuild#239 raised MSRV for trybuild to 1.67 (toml_datetime specifies this minimum), but CI workflow was updated to 1.70 in that PR, so this patch raises MSRV to 1.70 instead.

A reference to even older MSRV in the README is removed entirely since this information lives in Cargo.toml as of Rust 1.56.