### PR TITLE
Remove dependency on once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ diff = ["dissimilar"]
 [dependencies]
 dissimilar = { version = "1.0", optional = true }
 glob = "0.3"
-once_cell = "1.9"
 serde = "1.0.194"
 serde_derive = "1.0.194"
 serde_json = "1.0.110"

--- a/src/flock.rs
+++ b/src/flock.rs
@@ -1,14 +1,13 @@
 use crate::error::Result;
-use once_cell::sync::OnceCell;
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 use std::thread;
 use std::time::{Duration, SystemTime};
 
-static LOCK: OnceCell<Mutex<()>> = OnceCell::new();
+static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 pub(crate) struct Lock {
     intraprocess_guard: Guard,

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,9 +1,8 @@
-use once_cell::sync::OnceCell;
 use std::io::{Result, Write};
-use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream as Stream, WriteColor};
 
-static TERM: OnceCell<Mutex<Term>> = OnceCell::new();
+static TERM: OnceLock<Mutex<Term>> = OnceLock::new();
 
 pub(crate) fn lock() -> MutexGuard<'static, Term> {
     TERM.get_or_init(|| Mutex::new(Term::new()))


### PR DESCRIPTION
Our MSRV is now 1.70, so we can use `std::sync::OnceLock` instead of `once_cell::sync::OnceCell`.