### PR TITLE
Normalize the effect of `--verbose` on '$N others' diagnostic

### DIFF
--- a/src/tests/and-others-verbose.rs
+++ b/src/tests/and-others-verbose.rs
@@ -1,0 +1,151 @@
+test_normalize! {r#"
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+"# r#"
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+
+error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
+  --> tests/ui/on_unimplemented.rs:22:23
+   |
+22 |     let _: MyStruct = from_str("");
+   |                       ^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `MyStruct`
+   |
+   = help: the following other types implement trait `Deserialize<'de>`:
+             &'a Path
+             &'a [u8]
+             &'a str
+             ()
+             (T,)
+             (T0, T1)
+             (T0, T1, T2)
+             (T0, T1, T2, T3)
+             (T0, T1, T2, T3, T4)
+             (T0, T1, T2, T3, T4, T5)
+note: required by a bound in `from_str`
+  --> tests/ui/on_unimplemented.rs:13:8
+   |
+11 | fn from_str<'de, T>(_: &'de str) -> T
+   |    -------- required by a bound in this function
+12 | where
+13 |     T: Deserialize<'de>,
+   |        ^^^^^^^^^^^^^^^^ required by this bound in `from_str`
+"#}

--- a/src/tests/and-others-verbose.rs
+++ b/src/tests/and-others-verbose.rs
@@ -138,8 +138,7 @@ error[E0277]: the trait bound `MyStruct: Deserialize<'_>` is not satisfied
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
-             (T0, T1, T2, T3, T4)
-             (T0, T1, T2, T3, T4, T5)
+           and $N others
 note: required by a bound in `from_str`
   --> tests/ui/on_unimplemented.rs:13:8
    |


### PR DESCRIPTION
The `--verbose` flag from #270 was intended to control type name shortening (#269: _"consider using \`--verbose\` to print the full type name to the console"_). But it also changes the behavior of the kind of errors from #198. With `--verbose`, instead of _"and $N others"_ rustc will print the full list of other trait impls, regardless of how many.

This PR normalizes the effect of `--verbose` on such diagnostics so that they better resemble what a real user would see, and to reduce churn in ui tests containing long impl lists.