### PR TITLE
Combine all rustflags into cargo `--config` arg

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -38,10 +38,10 @@ fn cargo(project: &Project) -> Command {
     let mut cmd = raw_cargo();
     cmd.current_dir(&project.dir);
     cmd.envs(cargo_target_dir(project));
-    cmd.envs(rustflags::envs());
+    cmd.env_remove("RUSTFLAGS");
     cmd.env("CARGO_INCREMENTAL", "0");
     cmd.arg("--offline");
-    cmd.arg("--config=build.rustflags=[\"--verbose\"]");
+    cmd.arg(format!("--config=build.rustflags={}", rustflags::toml()));
     cmd
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -61,16 +61,6 @@ pub(crate) struct Bin {
 pub(crate) struct Name(pub String);
 
 #[derive(Serialize, Debug)]
-pub(crate) struct Config {
-    pub build: Build,
-}
-
-#[derive(Serialize, Debug)]
-pub(crate) struct Build {
-    pub rustflags: Vec<&'static str>,
-}
-
-#[derive(Serialize, Debug)]
 pub(crate) struct Workspace {
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub dependencies: Map<String, Dependency>,

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,10 +5,10 @@ use crate::env::Update;
 use crate::error::{Error, Result};
 use crate::expand::{expand_globs, ExpandedTest};
 use crate::flock::Lock;
-use crate::manifest::{Bin, Build, Config, Manifest, Name, Package, Workspace};
+use crate::manifest::{Bin, Manifest, Name, Package, Workspace};
 use crate::message::{self, Fail, Warn};
 use crate::normalize::{self, Context, Variations};
-use crate::{features, rustflags, Expected, Runner, Test};
+use crate::{features, Expected, Runner, Test};
 use serde_derive::Deserialize;
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::env;
@@ -182,12 +182,6 @@ impl Runner {
 
     fn write(&self, project: &mut Project) -> Result<()> {
         let manifest_toml = toml::to_string(&project.manifest)?;
-
-        let config = self.make_config();
-        let config_toml = toml::to_string(&config)?;
-
-        fs::create_dir_all(path!(project.dir / ".cargo"))?;
-        fs::write(path!(project.dir / ".cargo" / "config.toml"), config_toml)?;
         fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
 
         let main_rs = b"\
@@ -321,14 +315,6 @@ impl Runner {
         }
 
         Ok(manifest)
-    }
-
-    fn make_config(&self) -> Config {
-        Config {
-            build: Build {
-                rustflags: rustflags::make_vec(),
-            },
-        }
     }
 
     fn run_all(&self, project: &Project, tests: Vec<ExpandedTest>) -> Result<Report> {

--- a/src/rustflags.rs
+++ b/src/rustflags.rs
@@ -1,27 +1,12 @@
-use std::env;
-use std::ffi::OsString;
-
-const RUSTFLAGS: &str = "RUSTFLAGS";
 const IGNORED_LINTS: &[&str] = &["dead_code"];
 
-pub(crate) fn make_vec() -> Vec<&'static str> {
-    let mut rustflags = vec!["--cfg", "trybuild"];
+pub(crate) fn toml() -> toml::Value {
+    let mut rustflags = vec!["--cfg", "trybuild", "--verbose"];
 
     for &lint in IGNORED_LINTS {
         rustflags.push("-A");
         rustflags.push(lint);
     }
 
-    rustflags
-}
-
-pub(crate) fn envs() -> impl IntoIterator<Item = (&'static str, OsString)> {
-    let mut rustflags = env::var_os(RUSTFLAGS)?;
-
-    for flag in make_vec() {
-        rustflags.push(" ");
-        rustflags.push(flag);
-    }
-
-    Some((RUSTFLAGS, rustflags))
+    toml::Value::try_from(rustflags).unwrap()
 }


### PR DESCRIPTION
The `--verbose` flag from #270 is not being applied consistently in all environments because of interference with the RUSTFLAGS environment variable, which takes precedence (https://doc.rust-lang.org/1.79.0/cargo/reference/config.html#buildrustflags).

This PR consolidates all 3 previously used sources of flags (`.cargo/config.toml`, `$RUSTFLAGS`, `--config=build.rustflags`) into just using `--config=build.rustflags`.