### PR TITLE
Fix default features in dependency

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -135,11 +135,7 @@ pub(crate) struct Dependency {
     pub path: Option<Directory>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub optional: bool,
-    #[serde(
-        rename = "default-features",
-        default = "get_true",
-        skip_serializing_if = "is_true"
-    )]
+    #[serde(rename = "default-features", default = "get_true")]
     pub default_features: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub features: Vec<String>,

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -191,10 +191,6 @@ fn get_true() -> bool {
     true
 }
 
-fn is_true(boolean: &bool) -> bool {
-    *boolean
-}
-
 fn is_false(boolean: &bool) -> bool {
     !*boolean
 }


### PR DESCRIPTION
If in a crate `Cargo.toml` there is a dependency with `default-features = true` and `workspace = true`
If in the workspace `Cargo.toml` the depended crate is written with `default-features = false`

Then we must serialize the `default-features = true` when doing the manifest for the test.

Otherwise the test will run with `default-features = false` which is not the expected behavior.