### PR TITLE
Warn about the `rust-src` component footgun in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,16 @@ to catch. If the compiler changes something that makes error messages that we
 care about substantially worse, it is also important to catch and report as a
 compiler issue.
 
+## CI
+
+Make sure `rust-src` component is installed on CI, otherwise error messages
+on CI will not include snippets of code from the standard library. This will
+make sure the output on CI is the same as on your local machine.
+
+```bash
+rustup component add rust-src
+```
+
 <br>
 
 #### License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,16 @@
 //! important for a test suite to catch. If the compiler changes something that
 //! makes error messages that we care about substantially worse, it is also
 //! important to catch and report as a compiler issue.
+//!
+//! # CI
+//!
+//! Make sure `rust-src` component is installed on CI, otherwise error messages
+//! on CI will not include snippets of code from the standard library. This will
+//! make sure the output on CI is the same as on your local machine.
+//!
+//! ```bash
+//! rustup component add rust-src
+//! ```
 
 #![doc(html_root_url = "https://docs.rs/trybuild/1.0.99")]
 #![allow(


### PR DESCRIPTION
I've stumbled on a problem where my compile error messages locally differed from the output on CI. This caused trybuild tests not to pass on CI, but pass locally:

![image](https://github.com/user-attachments/assets/92b31ed6-7cf2-4cdc-b82b-399857e10ed6)

Helpful people on Rust Zulip/Discord suggested that the difference was that I didn't have `rust-src` installed on CI. And that appeared to be the cause.

I propose to add this caveat to the documentation so that people don't stumble on this again.