### PR TITLE
Rely on $TARGET always set during build script execution

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,12 +10,9 @@ fn main() -> io::Result<()> {
     println!("cargo:rustc-check-cfg=cfg(host_os, values(\"windows\"))");
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
-    let target = env::var("TARGET").ok();
+    let target = env::var("TARGET").unwrap();
     let path = Path::new(&out_dir).join("target");
-    let value = match target {
-        Some(target) => format!(r#"Some("{}")"#, target.escape_debug()),
-        None => "None".to_owned(),
-    };
+    let value = format!(r#""{}""#, target.escape_debug());
     fs::write(path, value)?;
 
     let host = env::var_os("HOST").unwrap();

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -184,10 +184,10 @@ fn features(project: &Project) -> Vec<String> {
 
 fn target() -> Vec<&'static str> {
     #[cfg(not(host_os = "windows"))]
-    const TARGET: Option<&str> = include!(concat!(env!("OUT_DIR"), "/target"));
+    const TARGET: &str = include!(concat!(env!("OUT_DIR"), "/target"));
 
     #[cfg(host_os = "windows")]
-    const TARGET: Option<&str> = include!(concat!(env!("OUT_DIR"), "\\target"));
+    const TARGET: &str = include!(concat!(env!("OUT_DIR"), "\\target"));
 
     // When --target flag is passed, cargo does not pass RUSTFLAGS to rustc when
     // building proc-macro and build script even if the host and target triples
@@ -204,9 +204,7 @@ fn target() -> Vec<&'static str> {
     // Therefore, expose a cfg to always treat the target as host.
     if cfg!(trybuild_no_target) {
         vec![]
-    } else if let Some(target) = TARGET {
-        vec!["--target", target]
     } else {
-        vec![]
+        vec!["--target", TARGET]
     }
 }


### PR DESCRIPTION
As far as I can tell, this is always set by Cargo for build scripts. https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts gives no indication otherwise.