### PR TITLE
Canonicalize paths used as map keys

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 macro_rules! path {
     ($($tt:tt)+) => {
         tokenize_path!([] [] $($tt)+)
@@ -31,10 +33,21 @@ macro_rules! tokenize_path {
     }};
 }
 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone)]
+pub(crate) struct CanonicalPath(PathBuf);
+
+impl CanonicalPath {
+    pub(crate) fn new(path: &Path) -> Self {
+        if let Ok(canonical) = path.canonicalize() {
+            CanonicalPath(canonical)
+        } else {
+            CanonicalPath(path.to_owned())
+        }
+    }
+}
+
 #[test]
 fn test_path_macro() {
-    use std::path::{Path, PathBuf};
-
     struct Project {
         dir: PathBuf,
     }


### PR DESCRIPTION
Closes #299. The filepaths that appear in rustc's `--message-format=json` JSON output can be inconsistent with the corresponding paths for the same test file produced by `project.source_dir.join(&t.test.path)`.