### PR TITLE
Making Cargo `--offline` Optional

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -41,7 +41,9 @@ fn cargo(project: &Project) -> Command {
     cmd.envs(cargo_target_dir(project));
     cmd.env_remove("RUSTFLAGS");
     cmd.env("CARGO_INCREMENTAL", "0");
-    cmd.arg("--offline");
+    if project.offline {
+        cmd.arg("--offline");
+    }
 
     let rustflags = rustflags::toml();
     cmd.arg(format!("--config=build.rustflags={rustflags}"));

--- a/src/env.rs
+++ b/src/env.rs
@@ -21,3 +21,13 @@ impl Update {
         }
     }
 }
+
+/// Function that examines the `TRYBUILD_OFFLINE_MODE` environment variable and
+/// returns a boolean indicating whether or not the `--offline` option should be
+/// passed to cargo.
+pub(crate) fn use_offline_mode() -> bool {
+    // if the environment variable is set (we don't care what value), then
+    // offline mode should be disabled. Otherwise, it should be enabled (the
+    // default behavior)
+    env::var_os("TRYBUILD_NO_OFFLINE_MODE").is_none()
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -22,9 +22,9 @@ impl Update {
     }
 }
 
-/// Function that examines the `TRYBUILD_OFFLINE_MODE` environment variable and
-/// returns a boolean indicating whether or not the `--offline` option should be
-/// passed to cargo.
+/// Function that examines the `TRYBUILD_NO_OFFLINE_MODE` environment variable
+/// and returns a boolean indicating whether or not the `--offline` option
+/// should be passed to cargo.
 pub(crate) fn use_offline_mode() -> bool {
     // if the environment variable is set (we don't care what value), then
     // offline mode should be disabled. Otherwise, it should be enabled (the

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,7 +1,7 @@
 use crate::cargo::{self, Metadata, PackageMetadata};
 use crate::dependencies::{self, Dependency, EditionOrInherit};
 use crate::directory::Directory;
-use crate::env::Update;
+use crate::env::{Update, use_offline_mode};
 use crate::error::{Error, Result};
 use crate::expand::{expand_globs, ExpandedTest};
 use crate::flock::Lock;
@@ -33,6 +33,7 @@ pub(crate) struct Project {
     pub path_dependencies: Vec<PathDependency>,
     manifest: Manifest,
     pub keep_going: bool,
+    pub offline: bool,
 }
 
 #[derive(Debug)]
@@ -165,6 +166,11 @@ impl Runner {
             enabled_features.retain(|feature| manifest.features.contains_key(feature));
         }
 
+        // By default, the project will run in offline mode (i.e., the
+        // `--offline` cargo option will be used). Check an environment variable
+        // to determine if offline mode should *not* be used.
+        let enable_offline_mode: bool = use_offline_mode();
+
         Ok(Project {
             dir: project_dir,
             source_dir,
@@ -178,6 +184,7 @@ impl Runner {
             path_dependencies,
             manifest,
             keep_going: false,
+            offline: enable_offline_mode,
         })
     }
 


### PR DESCRIPTION
This PR implements an environment variable that can be used to toggle the usage of the `--offline` option when trybuild invokes `cargo`. The default behavior has not been modified; `--offline` is still used by default, but there is now the option to disable the usage `--offline` by setting this environment variable:

```bash
TRYBUILD_NO_OFFLINE_MODE=1
```

Always invoking `cargo` with `--offline` was discussed in #50 and implemented in [this commit](https://github.com/dtolnay/trybuild/commit/24a173f9c99f4d23323b29e43bc1e2e1a835a266)). As discussed in #296, in some situations, trybuild is unable to access certain resources outside of the target directory. I've noticed a similar problem when setting `CARGO_TARGET_DIR` to somewhere else on the system (I have a constraint that requires this), and found that removing `--offline` allows dependencies to be pulled when trybuild sets the target directory [here in the code](https://github.com/dtolnay/trybuild/blob/master/src/cargo.rs#L53).

I figured, for this reason, and for others in the future, it may be handy to have the option to choose whether or not `--offline` is used by trybuild. Would love to hear any feedback and make suggested changes - thanks!