### PR TITLE
support passing `-C instrument-coverage` in RUSTFLAGS

### DIFF
--- a/src/rustflags.rs
+++ b/src/rustflags.rs
@@ -8,5 +8,14 @@ pub(crate) fn toml() -> toml::Value {
         rustflags.push(lint);
     }
 
+    if let Some(flags) = std::env::var("RUSTFLAGS").ok() {
+        // TODO: could parse this properly and allowlist (or blocklist?)
+        // certain flags. This is good enough to at least support
+        // `cargo-llvm-cov`.
+        if flags.contains("-C instrument-coverage") {
+            rustflags.extend(["-C", "instrument-coverage"]);
+        }
+    }
+
     toml::Value::try_from(rustflags).unwrap()
 }


### PR DESCRIPTION
Workaround for #283, specifically for the case of coverage with `cargo llvm-cov`.

From what I understand, since trybuild 1.0.97, RUSTFLAGS are blocked from the environment. This has the effect of breaking `cargo-llvm-cov` integration with trybuild tests, because it sets `-C instrument-coverage` in `RUSTFLAGS`.

As a result, we stopped getting coverage of PyO3 proc macro cases covered by UI tests (e.g. error cases which cause a compile failure). We'd been getting lucky that our MSRV job was producing that coverage against trybuild 1.0.89, but that won't last forever.

This PR is an attempt to restore that functionality. It's a bit crude, and I'm happy to rework or edit this to a design which you'd prefer. I'm more invested in getting this working again than I am in any particular implementation; I will defer to your opinion on how you want this to work.