### PR TITLE
Exposes environment variables for builds

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.70.0"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -4,6 +4,7 @@ use crate::manifest::Name;
 use crate::run::Project;
 use crate::rustflags;
 use serde_derive::Deserialize;
+use std::ffi::OsString;
 use std::fs::File;
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
@@ -113,7 +114,11 @@ pub(crate) fn build_dependencies(project: &mut Project) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn build_test(project: &Project, name: &Name) -> Result<Output> {
+pub(crate) fn build_test(
+    project: &Project,
+    name: &Name,
+    envs: &[(OsString, OsString)],
+) -> Result<Output> {
     let _ = cargo(project)
         .arg("clean")
         .arg("--package")
@@ -132,6 +137,7 @@ pub(crate) fn build_test(project: &Project, name: &Name) -> Result<Output> {
         .arg("--quiet")
         .arg("--color=never")
         .arg("--message-format=json")
+        .envs(envs.iter().map(|(k, v)| (k.as_os_str(), v.as_os_str())))
         .output()
         .map_err(Error::Cargo)
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -21,7 +21,15 @@ pub(crate) fn expand_globs(tests: &[Test]) -> Vec<ExpandedTest> {
                 Ok(paths) => {
                     let expected = test.expected;
                     for path in paths {
-                        set.insert(Test { path, expected }, None, true);
+                        set.insert(
+                            Test {
+                                path,
+                                expected,
+                                envs: test.envs.clone(),
+                            },
+                            None,
+                            true,
+                        );
                     }
                 }
                 Err(error) => set.insert(test.clone(), Some(error), false),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,7 @@ mod run;
 mod rustflags;
 
 use std::cell::RefCell;
+use std::ffi::OsString;
 use std::panic::RefUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::thread;
@@ -302,6 +303,7 @@ struct Runner {
 struct Test {
     path: PathBuf,
     expected: Expected,
+    envs: Vec<(OsString, OsString)>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -322,6 +324,22 @@ impl TestCases {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
             expected: Expected::Pass,
+            envs: Vec::new(),
+        });
+    }
+
+    pub fn pass_with_envs<P: AsRef<Path>>(
+        &self,
+        path: P,
+        envs: impl IntoIterator<Item = (impl Into<OsString>, impl Into<OsString>)>,
+    ) {
+        self.runner.borrow_mut().tests.push(Test {
+            path: path.as_ref().to_owned(),
+            expected: Expected::Pass,
+            envs: envs
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         });
     }
 
@@ -329,6 +347,22 @@ impl TestCases {
         self.runner.borrow_mut().tests.push(Test {
             path: path.as_ref().to_owned(),
             expected: Expected::CompileFail,
+            envs: Vec::new(),
+        });
+    }
+
+    pub fn compile_fail_with_envs<P: AsRef<Path>>(
+        &self,
+        path: P,
+        envs: impl IntoIterator<Item = (impl Into<OsString>, impl Into<OsString>)>,
+    ) {
+        self.runner.borrow_mut().tests.push(Test {
+            path: path.as_ref().to_owned(),
+            expected: Expected::CompileFail,
+            envs: envs
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
         });
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -377,7 +377,7 @@ impl Test {
         let src_path = CanonicalPath::new(&project.source_dir.join(&self.path));
         path_map.insert(src_path.clone(), (name, self));
 
-        let output = cargo::build_test(project, name)?;
+        let output = cargo::build_test(project, name, &self.envs)?;
         let parsed = parse_cargo_json(project, &output.stdout, &path_map);
         let fallback = Stderr::default();
         let this_test = parsed.stderrs.get(&src_path).unwrap_or(&fallback);


### PR DESCRIPTION
# Summary
I was testing a `proc-macro` that reads from a particular environment variable when I realized that `trybuild` will not pick `std::env::set` calls. I've added an `envs` field to the `Test` struct. This `envs` field is then used to extend the environment `cargo::build_test` method. I've also added some helper methods.

> [!NOTE]
> I put this together for my own use case. I'm opening this draft PR to see if there's any interest. I haven't added tests.

## Usage 

```rust
t.compile_fail_with_envs(
    "tests/ui/footnote-fail/*.rs", 
     vec![("FOO", "bar")]
);
```