### PR TITLE
README: Avoid directory traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,22 @@ components = ["rust-src"]
 
 <br>
 
+## Avoid directory traversal
+
+If you re-use the failing `.rs` files, have them (and their respective
+`.stderr` files) positioned so that `t.compile_fail(...)` accesses them only
+in subdirectories ("sub/sub/dir/test01.rs"), and not involving any parent
+traversal ("../neighbor-dir/tests01.rs"). Otherwise the generated `.stderr`
+files may include absolute resolved paths, and they may fail in different
+environment.
+
+Alternatively, create symlinks that involve any parent traversal "..". Have
+those symlinks themselves located under a (sub-sub...)directory of where you
+invoke `t.compile_fail(...)`, so that the path you pass to
+`t.compile_fail(...)` itself does not include any "..".
+
+<br>
+
 #### License
 
 <sup>


### PR DESCRIPTION
tl;dr Trybuild is better than it may seem for users with complex setups, who already have, or are used to having compilation-failing source files outside their `src/` tree.

For example, users may already have compilation-failing sources positioned somewhere outside `src/`, because of their existing script-based testing (that they want to move away from and move to `trybuild`).

Or, they may want to test (compilation failure) of the same sources under various combinations of features, but (for whatever reason) they don't want to pass the features to `cargo test`, but they set up one test crate per feature combination.

But It was only after some experimentation, almost an accident, that I've noticed that `trybuild` does store relative paths in `.stderr` (instead of absolute paths), but only if the path passed to `t.compile_fail(...)` does not contain "..".

I understand that there may be more restrictions on this, and that there's no guarantee. But, since this work, mentioning this, at least as a hint, would
- save people's time,
- attract more users, and
- reduce, at least partially, tickets like #320.