### PR TITLE
use `--diagnostic-width` rustflag to fix ui test output width

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -37,6 +37,10 @@ fn raw_cargo() -> Command {
 }
 
 fn cargo(project: &Project) -> Command {
+    cargo_with_rustflags(project, &[])
+}
+
+fn cargo_with_rustflags(project: &Project, extra_rustflags: &[&'static str]) -> Command {
     let mut cmd = raw_cargo();
     cmd.current_dir(&project.dir);
     cmd.envs(cargo_target_dir(project));
@@ -44,7 +48,7 @@ fn cargo(project: &Project) -> Command {
     cmd.env("CARGO_INCREMENTAL", "0");
     cmd.arg("--offline");
 
-    let rustflags = rustflags::toml();
+    let rustflags = rustflags::toml(extra_rustflags);
     cmd.arg(format!("--config=build.rustflags={rustflags}"));
     cmd.arg(format!("--config=target.{TARGET}.rustflags={rustflags}"));
 
@@ -122,7 +126,7 @@ pub(crate) fn build_test(project: &Project, name: &Name) -> Result<Output> {
         .stderr(Stdio::null())
         .status();
 
-    cargo(project)
+    cargo_with_rustflags(project, &["--diagnostic-width=140"])
         .arg(if project.has_pass { "build" } else { "check" })
         .args(target())
         .arg("--bin")
@@ -145,7 +149,7 @@ pub(crate) fn build_all_tests(project: &Project) -> Result<Output> {
         .stderr(Stdio::null())
         .status();
 
-    cargo(project)
+    cargo_with_rustflags(project, &["--diagnostic-width=140"])
         .arg(if project.has_pass { "build" } else { "check" })
         .args(target())
         .arg("--bins")

--- a/src/rustflags.rs
+++ b/src/rustflags.rs
@@ -2,7 +2,7 @@ use std::env;
 
 const IGNORED_LINTS: &[&str] = &["dead_code"];
 
-pub(crate) fn toml() -> toml::Value {
+pub(crate) fn toml(extra_rustflags: &[&'static str]) -> toml::Value {
     let mut rustflags = vec!["--cfg", "trybuild", "--verbose"];
 
     for &lint in IGNORED_LINTS {
@@ -17,6 +17,8 @@ pub(crate) fn toml() -> toml::Value {
             rustflags.extend(["-C", "instrument-coverage"]);
         }
     }
+
+    rustflags.extend(extra_rustflags);
 
     toml::Value::try_from(rustflags).unwrap()
 }


### PR DESCRIPTION
Fixes #324 

This uses the `--diagnostic-width` flag to rustc to ensure that output does not change with UI test size.

140 was selected as the [default width](https://github.com/rust-lang/rust/blob/7d8ebe3128fc87f3da1ad64240e63ccf07b8f0bd/compiler/rustc_session/src/session.rs#L519) if rustc cannot infer a width from a terminal (and also the same width that would be used if #315 was used on nightly).