### PR TITLE
Add TRYBUILD_NO_CFG to opt out of cfg injection and share parent target dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,27 @@ compiler issue.
 
 <br>
 
+## Sharing the build cache
+
+By default trybuild compiles each test case under a separate
+`target/tests/trybuild` directory and injects `--cfg trybuild` into the
+rustflags. Both keep trybuild's compilation fully isolated from whatever the
+surrounding workspace is doing.
+
+If your crate doesn't reference `cfg(trybuild)` anywhere, you can opt into
+sharing the parent workspace's incremental build cache by setting the
+environment variable `TRYBUILD_NO_CFG`. With that variable set, trybuild omits
+the `--cfg trybuild` rustflag and stops overriding `CARGO_TARGET_DIR`, so the
+spawned cargo invocation inherits the parent's target directory and can reuse
+already-compiled dependency artifacts. For projects with heavy dependency
+trees this can make trybuild's cold-cache time substantially shorter.
+
+Don't set this variable if your crate or any of its dependencies reference
+`cfg(trybuild)` — those branches would otherwise be compiled as if trybuild
+were absent.
+
+<br>
+
 ## Troubleshooting
 
 The Rust compiler's diagnostic output can vary as a function of whether the

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -7,7 +7,7 @@ use serde_derive::Deserialize;
 use std::fs::File;
 use std::path::PathBuf;
 use std::process::{Command, Output, Stdio};
-use std::{env, io, iter};
+use std::{env, io};
 use target_triple::TARGET;
 
 #[derive(Deserialize)]
@@ -55,11 +55,15 @@ fn cargo_with_rustflags(project: &Project, extra_rustflags: &[&'static str]) -> 
     cmd
 }
 
-fn cargo_target_dir(project: &Project) -> impl Iterator<Item = (&'static str, PathBuf)> {
-    iter::once((
-        "CARGO_TARGET_DIR",
-        path!(project.target_dir / "tests" / "trybuild"),
-    ))
+fn cargo_target_dir(project: &Project) -> Vec<(&'static str, PathBuf)> {
+    if env::var_os("TRYBUILD_NO_CFG").is_some() {
+        Vec::new()
+    } else {
+        vec![(
+            "CARGO_TARGET_DIR",
+            path!(project.target_dir / "tests" / "trybuild"),
+        )]
+    }
 }
 
 pub(crate) fn manifest_dir() -> Result<Directory> {

--- a/src/rustflags.rs
+++ b/src/rustflags.rs
@@ -3,7 +3,11 @@ use std::env;
 const IGNORED_LINTS: &[&str] = &["dead_code"];
 
 pub(crate) fn toml(extra_rustflags: &[&'static str]) -> toml::Value {
-    let mut rustflags = vec!["--cfg", "trybuild", "--verbose"];
+    let mut rustflags = if env::var_os("TRYBUILD_NO_CFG").is_some() {
+        vec!["--verbose"]
+    } else {
+        vec!["--cfg", "trybuild", "--verbose"]
+    };
 
     for &lint in IGNORED_LINTS {
         rustflags.push("-A");


### PR DESCRIPTION
Adds an opt-in `TRYBUILD_NO_CFG` env var. When set:

- `rustflags::toml` omits `--cfg trybuild` from the rustflags passed to spawned cargo.
- `cargo::cargo_target_dir` returns no `CARGO_TARGET_DIR` override, so the parent's value (or absence) flows through.

Both halves are needed together. The cfg perturbs the rustc fingerprint, and the target-dir override means cargo never gets the chance to compare fingerprints anyway — either alone leaves the spawned cargo recompiling from cold.

When unset, behavior is unchanged. Filed as #328.

Verified end-to-end with a smoke harness:

```
$ cargo clean && cargo test
$ ls target/tests/trybuild/
debug/  trybuild-smoke/  x86_64-unknown-linux-gnu/

$ cargo clean && TRYBUILD_NO_CFG=1 cargo test
$ ls target/tests/trybuild/
trybuild-smoke/
$ ls target/debug/incremental/
trybuild_smoke-...
```

Baseline: spawned cargo writes artifacts under `target/tests/trybuild/{debug,x86_64-...}`. With `TRYBUILD_NO_CFG=1`, those subdirs are absent and the spawned cargo's incremental output lands under `target/debug/` instead.

Trybuild's existing tests pass (26/26) with no test changes — they're normalization fixtures that don't spawn cargo. I considered adding a unit test that asserts `rustflags::toml()` returns different values based on the env var, but env-mutation tests are racy without serialization; let me know if you'd prefer it added and which approach you'd want.

Related: #305 (narrow rustflags carve-out for `-C instrument-coverage`), #106 / #283 (same friction from different angles).