### PR TITLE
Prefer longest match in path dependency search

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -2,7 +2,7 @@ use serde::de::{Deserialize, Deserializer};
 use serde_derive::Serialize;
 use std::borrow::Cow;
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -25,6 +25,10 @@ impl Directory {
 
     pub fn to_string_lossy(&self) -> Cow<str> {
         self.path.to_string_lossy()
+    }
+
+    pub fn as_os_str(&self) -> &OsStr {
+        self.path.as_os_str()
     }
 
     pub fn join<P: AsRef<Path>>(&self, tail: P) -> PathBuf {

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,6 +11,7 @@ use crate::normalize::{self, Context, Normalization, Variations};
 use crate::path::CanonicalPath;
 use crate::{Expected, Runner, Test, features};
 use serde_derive::Deserialize;
+use std::cmp::Reverse;
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::env;
 use std::ffi::{OsStr, OsString};
@@ -163,6 +164,10 @@ impl Runner {
                 Normalization::MorePathDependencies,
             );
         }
+
+        // Sort by decreasing path length so that a linear scan can use the
+        // first match knowing it is the longest match.
+        path_dependencies.sort_by_key(|dep| Reverse(dep.normalized_path.as_os_str().len()));
 
         let crate_name = &source_manifest.package.name;
         let project_dir = path!(target_dir / "tests" / "trybuild" / crate_name /);


### PR DESCRIPTION
The previous behavior was the match having the alphanumerically least name would be used in the replacement, which isn't a justifiable behavior.

```toml
[dependencies]
a = { path = "../b/a" }  # $A/src/lib.rs
b = { path = "../b" }    # $B/src/lib.rs
c = { path = "../b/c" }  # $B/c/src/lib.rs
```

After this PR the new behavior uses the longest match: `$A/src/lib.rs`, `$B/src/lib.rs`, `$C/src/lib.rs`.

Always using shortest match would also produce reasonable behavior. `$B/a/src/lib.rs`, `$B/src/lib.rs`, `$B/c/src/lib.rs`